### PR TITLE
Hotfix: Control snapshot in Exasol, Record tracking satellite (rsrc_static not defined) all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### Features
 With datavault4dbt you will get a lot of awesome features, including:
 - A Data Vault 2.0 implementation congruent to the original Data Vault 2.0 definition by Dan Linstedt
-- Ready for both Persistent Staging Areas and Transient Staging Areas, due to the allowance of multiple deltas in all macros, without loosing any intermediate changes- Enforcing standards in naming conventions by implementing [global variables](Global-variables.md) for technical columns    
+- Ready for both Persistent Staging Areas and Transient Staging Areas, due to the allowance of multiple deltas in all macros, without loosing any intermediate changes- Enforcing standards in naming conventions by implementing [global variables](https://github.com/ScalefreeCOM/datavault4dbt/wiki/Global-variables) for technical columns    
 - A fully auditable solution for a Data Warehouse
 - Creating a centralized, snapshot-based Business interface by using a centralized snapshot table supporting logarithmic logic
 - A modern insert-only approach that avoids updating data

--- a/macros/tables/bigquery/rec_track_sat.sql
+++ b/macros/tables/bigquery/rec_track_sat.sql
@@ -19,8 +19,7 @@
 
 
 {# If no specific hk_column is defined for each source, we apply the values set in the tracked_hashkey input variable. #}
-{# If no rsrc_static parameter is defined in a source model then it is assumed that the record source column for that source is always static  #}
-{# If rsrc_static in any of the models is defined as the wild card '*' then the record source performance look up won't be executed #}
+{# If no rsrc_static parameter is defined in a source model then the record source performance look up wont be executed  #}
 {%- for source_model in source_models.keys() %}
 
     {%- if 'hk_column' not in source_models[source_model].keys() -%}

--- a/macros/tables/control_snap_v1.sql
+++ b/macros/tables/control_snap_v1.sql
@@ -45,6 +45,9 @@
 
                                             The duration is always counted from the current date.
 
+                                            EXASOL: Due to a missing "DAY OF WEEK" Function in Exasol, is_weekly is currently
+                                                    not supported and needs to be left out of the log_logic definition.
+
                                             Examples:
                                                 {'daily': {'duration': 3,               This configuration would keep daily
                                                             'unit': 'MONTH',            snapshots for 3 months, weekly snapshots

--- a/macros/tables/exasol/control_snap_v1.sql
+++ b/macros/tables/exasol/control_snap_v1.sql
@@ -94,7 +94,6 @@ virtual_logic AS (
         c.caption,
         c.is_hourly,
         c.is_daily,
-        c.is_weekly,
         c.is_monthly,
         c.is_yearly,
         CASE
@@ -133,7 +132,6 @@ active_logic_combined AS (
         caption,
         is_hourly,
         is_daily,
-        is_weekly,
         is_monthly,
         is_yearly,
         is_current_year,

--- a/macros/tables/exasol/rec_track_sat.sql
+++ b/macros/tables/exasol/rec_track_sat.sql
@@ -19,8 +19,7 @@
 
 
 {# If no specific hk_column is defined for each source, we apply the values set in the tracked_hashkey input variable. #}
-{# If no rsrc_static parameter is defined in a source model then it is assumed that the record source column for that source is always static  #}
-{# If rsrc_static in any of the models is defined as the wild card '*' then the record source performance look up won't be executed #}
+{# If no rsrc_static parameter is defined in a source model then the record source performance look up wont be executed  #}
 {%- for source_model in source_models.keys() %}
 
     {%- if 'hk_column' not in source_models[source_model].keys() -%}
@@ -28,18 +27,15 @@
     {%- endif -%}
 
     {%- if 'rsrc_static' not in source_models[source_model].keys() -%}
-        {%- set unique_rsrc = datavault4dbt.get_distinct_value(source_relation=ref(source_model), column_name=src_rsrc, exclude_values=[rsrc_unknown, rsrc_error]) -%}
-        {%- do ns.source_models_rsrc_dict.update({source_model : [unique_rsrc] } ) -%}
+        {%- set ns.has_rsrc_static_defined = false -%}
     {%- else -%}
 
         {%- if not (source_models[source_model]['rsrc_static'] is iterable and source_models[source_model]['rsrc_static'] is not string) -%}
 
             {%- if source_models[source_model]['rsrc_static'] == '' or source_models[source_model]['rsrc_static'] is none -%}
                 {%- if execute -%}
-                    {{ exceptions.raise_compiler_error("rsrc_static must not be an empty string ") }}
+                    {{ exceptions.raise_compiler_error("If rsrc_static is defined -> it must not be an empty string ") }}
                 {%- endif %}
-            {%- elif source_models[source_model]['rsrc_static'] == '*'-%}
-                {%- set ns.has_rsrc_static_defined = false -%}
             {%- else -%}
                 {%- do ns.source_models_rsrc_dict.update({source_model : [source_models[source_model]['rsrc_static']] } ) -%}
             {%- endif -%}

--- a/macros/tables/snowflake/rec_track_sat.sql
+++ b/macros/tables/snowflake/rec_track_sat.sql
@@ -19,8 +19,7 @@
 
 
 {# If no specific hk_column is defined for each source, we apply the values set in the tracked_hashkey input variable. #}
-{# If no rsrc_static parameter is defined in a source model then it is assumed that the record source column for that source is always static  #}
-{# If rsrc_static in any of the models is defined as the wild card '*' then the record source performance look up won't be executed #}
+{# If no rsrc_static parameter is defined in a source model then the record source performance look up wont be executed  #}
 {%- for source_model in source_models.keys() %}
 
     {%- if 'hk_column' not in source_models[source_model].keys() -%}


### PR DESCRIPTION
is_weekly check is not supported in Exasol version Control Snapshot tables.
Global variables link in README.md was broken
Record tracking satellite macro converged in all DB versions - if no rsrc_static is defined in any models then the record source lookup wont be executed.