### PR TITLE
Hotfix pit snowflake

### DIFF
--- a/macros/tables/bigquery/pit.sql
+++ b/macros/tables/bigquery/pit.sql
@@ -72,7 +72,7 @@ pit_records AS (
                 {% if ledts|string|lower in sat_columns|map('lower') %}
                     AND snap.{{ sdts }} BETWEEN {{ satellite }}.{{ ldts }} AND {{ satellite }}.{{ ledts }}
                 {%- else -%}
-                    AND {{ satellite }}.{{ ldts }} > snap.{{ sdts }}
+                    AND {{ satellite }}.{{ ldts }} >= snap.{{ sdts }}
                 {%- endif -%}
         {% endfor %}
     {% if datavault4dbt.is_something(snapshot_trigger_column) -%}

--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -74,7 +74,7 @@ pit_records AS (
                 {% if ledts|string|lower in sat_columns|map('lower') %}
                     AND snap.{{ sdts }} BETWEEN {{ satellite }}.{{ ldts }} AND {{ satellite }}.{{ ledts }}
                 {%- else -%}
-                    AND {{ satellite }}.{{ ldts }} > snap.{{ sdts }}
+                    AND {{ satellite }}.{{ ldts }} >= snap.{{ sdts }}
                 {%- endif -%}
         {% endfor %}
     {% if datavault4dbt.is_something(snapshot_trigger_column) -%}


### PR DESCRIPTION
Fixed some issues in PIT macro for snowflake:

- Quoting of pit_type value in column and hashing
- zero key of sat hkeys was not generated correctly
- the comparison of sdts with ldts changed from > to >= (otherwise a record with exactly the same ldts than the sdts would not be detected)