### PR TITLE
Fix bug in Stage Macro when sequence/include_source_columns is defined but it is empty

### DIFF
--- a/macros/staging/bigquery/stage.sql
+++ b/macros/staging/bigquery/stage.sql
@@ -80,7 +80,7 @@
 
 {%- endif %}
 
-{%- if sequence is not none -%}
+{%- if datavault4dbt.is_something(sequence) -%}
   {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [sequence] -%}
 {%- endif -%}
 
@@ -177,7 +177,7 @@ ldts_rsrc_data AS (
   SELECT
     {{ ldts }} AS {{ load_datetime_col_name}},
     CAST( {{ rsrc }} as {{ rsrc_default_dtype }} ) AS {{ record_source_col_name }}
-    {%- if sequence is not none %},
+    {%- if datavault4dbt.is_something(sequence) %},
       {{ sequence }} AS edwSequence
       {%- set alias_columns = alias_columns + ['edwSequence'] -%}
     {% endif -%}

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -79,7 +79,7 @@
 
 {%- endif %}
 
-{%- if sequence is not none -%}
+{%- if datavault4dbt.is_something(sequence) -%}
   {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [sequence] -%}
 {%- endif -%}
 
@@ -179,7 +179,7 @@ ldts_rsrc_data AS (
   SELECT
     {{ ldts }} AS {{ load_datetime_col_name}},
     CAST( {{ rsrc }} as {{ rsrc_default_dtype }} ) AS {{ record_source_col_name }}
-    {%- if sequence is not none %},
+    {%- if datavault4dbt.is_something(sequence) %},
       {{ sequence }} AS edwSequence
       {%- set alias_columns = alias_columns + ['edwSequence'] -%}
     {% endif -%}

--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -80,7 +80,7 @@
 
 {%- endif %}
 
-{%- if sequence is not none -%}
+{%- if datavault4dbt.is_something(sequence) -%}
   {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [sequence] -%}
 {%- endif -%}
 
@@ -177,7 +177,7 @@ ldts_rsrc_data AS (
   SELECT
     {{ ldts }} AS {{ load_datetime_col_name}},
     CAST( {{ rsrc }} as {{ rsrc_default_dtype }} ) AS {{ record_source_col_name }}
-    {%- if sequence is not none %},
+    {%- if datavault4dbt.is_something(sequence) %},
       {{ sequence }} AS edwSequence
       {%- set alias_columns = alias_columns + ['edwSequence'] -%}
     {% endif -%}

--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -105,6 +105,11 @@
 
   {%- macro stage(ldts, rsrc, source_model, include_source_columns=true, hashed_columns=none, derived_columns=none, sequence=none, prejoined_columns=none, missing_columns=none, multi_active_config=none) -%}
     
+    {# If include_source_columns is passed but its empty then it is set with the default value (true) #}
+    {%- if not datavault4dbt.is_something(include_source_columns) -%}
+      {%- set include_source_columns = true -%}
+    {%- endif -%}
+
     {{- adapter.dispatch('stage', 'datavault4dbt')(include_source_columns=include_source_columns,
                                         ldts=ldts,
                                         rsrc=rsrc,


### PR DESCRIPTION
In the Stage macro the if statement with "is not none" only works if the sequence is not defined at all, so when it is defined and it is empty it will lead to compilation error due to printing "as edwSequence" without an input before.  Using the macro datavault4dbt.is_something() fixes this issue.
Also the if include_source_columns will lead to a compilation error if the parameter is passed as empty. This issue is fixed in the general dispatcher Stage macro.