### PR TITLE
Added feature : different alias in ma_sat_v0 for Hashdiff

### DIFF
--- a/macros/tables/bigquery/ma_sat_v0.sql
+++ b/macros/tables/bigquery/ma_sat_v0.sql
@@ -4,7 +4,16 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set source_cols = datavault4dbt.expand_column_list(columns=[parent_hashkey, src_hashdiff, src_ldts, src_rsrc, src_ma_key, src_payload]) -%}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
+    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
+    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
+{% else %}
+    {% set ns.src_hashdiff = src_hashdiff %}
+    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- endif -%}
+
+{%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_ma_key, src_payload]) -%}
 
 {%- set source_relation = ref(source_model) -%}
 
@@ -15,6 +24,8 @@ WITH
 source_data AS (
 
     SELECT
+        {{ parent_hashkey }},
+        {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -34,7 +45,7 @@ latest_entries_in_sat AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ src_hashdiff }}
+        {{ ns.hdiff_alias }}
     FROM 
         {{ this }}
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
@@ -47,10 +58,10 @@ deduped_row_hashdiff AS (
   SELECT 
     {{ parent_hashkey }},
     {{ src_ldts }},
-    {{ src_hashdiff }}
+    {{ ns.hdiff_alias }}
   FROM source_data
   QUALIFY CASE
-            WHEN {{ src_hashdiff }} = LAG({{ src_hashdiff }}) OVER (PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER (PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
           END
 ),
@@ -59,18 +70,22 @@ deduped_row_hashdiff AS (
 deduped_rows AS (
 
   SELECT 
+    source_data.{{ parent_hashkey }},
+    source_data.{{ ns.hdiff_alias }},
     {{ datavault4dbt.alias_all(columns=source_cols, prefix='source_data') }}
   FROM source_data
   INNER JOIN deduped_row_hashdiff
     ON {{ datavault4dbt.multikey(parent_hashkey, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
     AND {{ datavault4dbt.multikey(src_ldts, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
-    AND {{ datavault4dbt.multikey(src_hashdiff, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
+    AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
 
 ),
 
 records_to_insert AS (
 
     SELECT
+        deduped_rows.{{ parent_hashkey }},
+        deduped_rows.{{ ns.hdiff_alias }},
         {{ datavault4dbt.alias_all(columns=source_cols, prefix='deduped_rows') }}
     FROM deduped_rows
     {%- if is_incremental() %}
@@ -78,12 +93,11 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }}
-            AND {{ datavault4dbt.multikey(src_hashdiff, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }} 
+            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }} 
             )
     {%- endif %}
 
     )
-
 
 SELECT * FROM records_to_insert
 

--- a/macros/tables/exasol/ma_sat_v0.sql
+++ b/macros/tables/exasol/ma_sat_v0.sql
@@ -4,7 +4,16 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set source_cols = datavault4dbt.expand_column_list(columns=[parent_hashkey, src_hashdiff, src_ldts, src_rsrc, src_ma_key, src_payload]) -%}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
+    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
+    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
+{% else %}
+    {% set ns.src_hashdiff = src_hashdiff %}
+    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- endif -%}
+
+{%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_ma_key, src_payload]) -%}
 
 {%- set source_relation = ref(source_model) -%}
 
@@ -15,6 +24,8 @@ WITH
 source_data AS (
 
     SELECT
+        {{ parent_hashkey }},
+        {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -34,7 +45,7 @@ latest_entries_in_sat AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ src_hashdiff }}
+        {{ ns.hdiff_alias }}
     FROM 
         {{ this }}
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
@@ -47,10 +58,10 @@ deduped_row_hashdiff AS (
   SELECT 
     {{ parent_hashkey }},
     {{ src_ldts }},
-    {{ src_hashdiff }}
+    {{ ns.hdiff_alias }}
   FROM source_data
   QUALIFY CASE
-            WHEN {{ src_hashdiff }} = LAG({{ src_hashdiff }}) OVER (PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER (PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
           END
 ),
@@ -59,18 +70,22 @@ deduped_row_hashdiff AS (
 deduped_rows AS (
 
   SELECT 
+    source_data.{{ parent_hashkey }},
+    source_data.{{ ns.hdiff_alias }},
     {{ datavault4dbt.alias_all(columns=source_cols, prefix='source_data') }}
   FROM source_data
   INNER JOIN deduped_row_hashdiff
     ON {{ datavault4dbt.multikey(parent_hashkey, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
     AND {{ datavault4dbt.multikey(src_ldts, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
-    AND {{ datavault4dbt.multikey(src_hashdiff, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
+    AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
 
 ),
 
 records_to_insert AS (
 
     SELECT
+        deduped_rows.{{ parent_hashkey }},
+        deduped_rows.{{ ns.hdiff_alias }},
         {{ datavault4dbt.alias_all(columns=source_cols, prefix='deduped_rows') }}
     FROM deduped_rows
     {%- if is_incremental() %}
@@ -78,7 +93,7 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }}
-            AND {{ datavault4dbt.multikey(src_hashdiff, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }} 
+            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }} 
             )
     {%- endif %}
 
@@ -86,5 +101,4 @@ records_to_insert AS (
 
 
 SELECT * FROM records_to_insert
-
 {%- endmacro -%}

--- a/macros/tables/snowflake/ma_sat_v0.sql
+++ b/macros/tables/snowflake/ma_sat_v0.sql
@@ -4,9 +4,19 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set source_cols = datavault4dbt.expand_column_list(columns=[parent_hashkey, src_hashdiff, src_ldts, src_rsrc, src_ma_key, src_payload]) -%}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
+    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
+    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
+{% else %}
+    {% set ns.src_hashdiff = src_hashdiff %}
+    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- endif -%}
+
+{%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_ma_key, src_payload]) -%}
 
 {%- set source_relation = ref(source_model) -%}
+
 
 WITH
 
@@ -14,6 +24,8 @@ WITH
 source_data AS (
 
     SELECT
+        {{ parent_hashkey }},
+        {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -33,10 +45,10 @@ latest_entries_in_sat AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ src_hashdiff }}
+        {{ ns.hdiff_alias }}
     FROM 
         {{ this }}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
 ),
 {%- endif %}
 
@@ -46,10 +58,10 @@ deduped_row_hashdiff AS (
   SELECT 
     {{ parent_hashkey }},
     {{ src_ldts }},
-    {{ src_hashdiff }}
+    {{ ns.hdiff_alias }}
   FROM source_data
   QUALIFY CASE
-            WHEN {{ src_hashdiff }} = LAG({{ src_hashdiff }}) OVER (PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER (PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
           END
 ),
@@ -58,18 +70,22 @@ deduped_row_hashdiff AS (
 deduped_rows AS (
 
   SELECT 
+    source_data.{{ parent_hashkey }},
+    source_data.{{ ns.hdiff_alias }},
     {{ datavault4dbt.alias_all(columns=source_cols, prefix='source_data') }}
   FROM source_data
   INNER JOIN deduped_row_hashdiff
     ON {{ datavault4dbt.multikey(parent_hashkey, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
     AND {{ datavault4dbt.multikey(src_ldts, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
-    AND {{ datavault4dbt.multikey(src_hashdiff, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
+    AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['source_data', 'deduped_row_hashdiff'], condition='=') }}
 
 ),
 
 records_to_insert AS (
 
     SELECT
+        deduped_rows.{{ parent_hashkey }},
+        deduped_rows.{{ ns.hdiff_alias }},
         {{ datavault4dbt.alias_all(columns=source_cols, prefix='deduped_rows') }}
     FROM deduped_rows
     {%- if is_incremental() %}
@@ -77,12 +93,11 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }}
-            AND {{ datavault4dbt.multikey(src_hashdiff, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }} 
+            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduped_rows'], condition='=') }} 
             )
     {%- endif %}
 
     )
-
 
 SELECT * FROM records_to_insert
 


### PR DESCRIPTION
This was missing : possibility to define hashdiff with input source column and alias with different name than the name of the source col. This feature is present already in sat_v0 macro, should also be present here.