### PR TITLE
Bugfixes - PIT, Sat_v0 and new feature in as_constant

### DIFF
--- a/macros/internal/metadata_processing/as_constant.sql
+++ b/macros/internal/metadata_processing/as_constant.sql
@@ -14,7 +14,15 @@
         
         {%- else -%}
         
-            {{- return(column_str) -}}
+            {%- if datavault4dbt.is_expression(column_str) -%}
+
+                {{- return(column_str) -}}
+
+            {%- else -%}
+
+                {{- return(datavault4dbt.escape_column_names(column_str)) -}}
+
+            {%- endif -%}
 
         {%- endif -%}
     {%- else -%}

--- a/macros/tables/bigquery/pit.sql
+++ b/macros/tables/bigquery/pit.sql
@@ -65,13 +65,13 @@ pit_records AS (
                 ON 1=1
             {%- endif %}
         {% for satellite in sat_names %}
-        {%- set sat_columns = datavault4dbt.source_columns(ref(satellite)) -%}
+        {%- set sat_columns = datavault4dbt.source_columns(ref(satellite)) %}
         LEFT JOIN {{ ref(satellite) }}
             ON
                 {{ satellite }}.{{ hashkey}} = te.{{ hashkey }}
                 {% if ledts|string|lower in sat_columns|map('lower') %}
                     AND snap.{{ sdts }} BETWEEN {{ satellite }}.{{ ldts }} AND {{ satellite }}.{{ ledts }}
-                {%- else -%}
+                {%- else %}
                     AND {{ satellite }}.{{ ldts }} >= snap.{{ sdts }}
                 {%- endif -%}
         {% endfor %}

--- a/macros/tables/bigquery/sat_v0.sql
+++ b/macros/tables/bigquery/sat_v0.sql
@@ -46,7 +46,7 @@ latest_entries_in_sat AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ src_hashdiff }}
+        {{ ns.hdiff_alias }}
     FROM 
         {{ this }}
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  

--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -67,13 +67,13 @@ pit_records AS (
                 ON 1=1
             {%- endif %}
         {% for satellite in sat_names %}
-        {%- set sat_columns = datavault4dbt.source_columns(ref(satellite)) -%}
+        {%- set sat_columns = datavault4dbt.source_columns(ref(satellite)) %}
         LEFT JOIN {{ ref(satellite) }}
             ON
                 {{ satellite }}.{{ hashkey}} = te.{{ hashkey }}
                 {% if ledts|string|lower in sat_columns|map('lower') %}
                     AND snap.{{ sdts }} BETWEEN {{ satellite }}.{{ ldts }} AND {{ satellite }}.{{ ledts }}
-                {%- else -%}
+                {%- else %}
                     AND {{ satellite }}.{{ ldts }} >= snap.{{ sdts }}
                 {%- endif -%}
         {% endfor %}

--- a/macros/tables/exasol/sat_v0.sql
+++ b/macros/tables/exasol/sat_v0.sql
@@ -46,7 +46,7 @@ latest_entries_in_sat AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ src_hashdiff }}
+        {{ ns.hdiff_alias }}
     FROM 
         {{ this }}
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -46,7 +46,7 @@ latest_entries_in_sat AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ src_hashdiff }}
+        {{ ns.hdiff_alias }}
     FROM 
         {{ this }}
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  


### PR DESCRIPTION
### Bugfix in the PIT macro - Exasol and BigQuery version : 
The dash in the closing curly brackets(line 70 and 76 in Exasol) led to a lack of whitespace between the first and second iteration of the loop(when there is more than one source model) in the line 71... so the model when having two sources would run into an error because the line 75 or 77 would be glued with the line 71 that starts the LEFT JOIN again.  Removing these dashes of the closing curly brackets fixes the issue.
### Bugfix in the sat_v0 - all versions:
When using a different alias for hashdiff, the incremental run in the latest_entries_in_sat CTE fails because it tries to select the hashdiff with the name of the input column present in the source stage.
Replacing the variable src_hashdiff with ns.hdiff_alias in the latest_entries_in_sat CTE fixes this issue.
### New feature in the helper as_constant macro - default version:
The user is now allowed to pass the column as an expression or pass the column input within double quotes. The macro will treat each case differently, returning the column as it is in the first case, and escaping the column name in the second case.