### PR TITLE
Fix of include_source_columns set of default value - Stage macro

### DIFF
--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -106,7 +106,7 @@
   {%- macro stage(ldts, rsrc, source_model, include_source_columns=true, hashed_columns=none, derived_columns=none, sequence=none, prejoined_columns=none, missing_columns=none, multi_active_config=none) -%}
     
     {# If include_source_columns is passed but its empty then it is set with the default value (true) #}
-    {%- if not datavault4dbt.is_something(include_source_columns) -%}
+    {%- if include_source_columns is none or include_source_columns == "" -%}
       {%- set include_source_columns = true -%}
     {%- endif -%}
 


### PR DESCRIPTION
There was a problem with the previous fix in the Stage macro dispatching file, even when setting in the model the include_source_columns as false it was resetting here as true because of the logic inside the macro is_something.