### PR TITLE
Added DISTINCT statement to support MAS in PIT macro

### DIFF
--- a/macros/tables/bigquery/pit.sql
+++ b/macros/tables/bigquery/pit.sql
@@ -83,7 +83,7 @@ pit_records AS (
 
 records_to_insert AS (
 
-    SELECT *
+    SELECT DISTINCT *
     FROM pit_records
     {%- if is_incremental() %}
     WHERE {{ dimension_key }} NOT IN (SELECT * FROM existing_dimension_keys)

--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -85,7 +85,7 @@ pit_records AS (
 
 records_to_insert AS (
 
-    SELECT *
+    SELECT DISTINCT *
     FROM pit_records
     {%- if is_incremental() %}
     WHERE {{ dimension_key }} NOT IN (SELECT * FROM existing_dimension_keys)

--- a/macros/tables/snowflake/pit.sql
+++ b/macros/tables/snowflake/pit.sql
@@ -85,7 +85,7 @@ pit_records AS (
 
 records_to_insert AS (
 
-    SELECT *
+    SELECT DISTINCT *
     FROM pit_records
     {%- if is_incremental() %}
     WHERE {{ dimension_key }} NOT IN (SELECT * FROM existing_dimension_keys)


### PR DESCRIPTION
With this statement we now get only the distinct rows, so it now can support MA satellites since when joining with an SMA we would get duplicates because of the multiple rows related to the same hashkey