### PR TITLE
Fixed wrong "is_weekly" in snap_v0 for Snowflake

### DIFF
--- a/macros/tables/snowflake/control_snap_v0.sql
+++ b/macros/tables/snowflake/control_snap_v0.sql
@@ -39,7 +39,7 @@ enriched_timestamps AS (
             ELSE FALSE
         END AS is_daily,
         CASE
-            WHEN EXTRACT(DAYOFWEEK FROM  sdts) = 2 THEN TRUE
+            WHEN EXTRACT(DAYOFWEEK FROM  sdts) = 1 THEN TRUE
             ELSE FALSE
         END AS is_weekly,
         CASE


### PR DESCRIPTION
# Bugfixes

- **Control Snap v0** (Snowflake): "is_weekly" was set incorrectly, when DAYOFWEEK = 2. It is now set to DAYOFWEEK = 1 to set "is_weekly" to true for each Monday. If "is_weekly" still doesn't populate correctly for you, validate that the Snowflake Parameter [WEEK_START](https://docs.snowflake.com/en/sql-reference/parameters.html#week-start) is set to 0, by executing the following command in your Snowflake Session: 
`ALTER SESSION SET WEEK_START = 0;`

## Contributors
- @mjahammel Thanks for finding this issue!