### PR TITLE
Fixed usage of zero keys in PIT macros for non-string datatypes

### DIFF
--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -53,7 +53,7 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
-            COALESCE({{ satellite }}.{{ hashkey }}, CAST('{{ unknown_key }}' AS {{ hash_dtype }})) AS hk_{{ satellite }},
+            COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
             {{- "," if not loop.last }}
         {%- endfor %}

--- a/macros/tables/snowflake/pit.sql
+++ b/macros/tables/snowflake/pit.sql
@@ -53,7 +53,7 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {%- for satellite in sat_names %}
-            COALESCE({{ satellite }}.{{ hashkey }}, CAST('{{ unknown_key }}' AS {{ hash_dtype }})) AS hk_{{ satellite }},
+            COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
             {{- "," if not loop.last }}
         {%- endfor %}


### PR DESCRIPTION
## Bugfixes
- **PIT** (All adapters): The zero key usage is now wrapped inside the "as_constant" macro, to make the zero key for BINARY/BYTES hash datatypes work. 