### PR TITLE
Raised dbt utils requirements to <2.0.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<1.0.0"]
+    version: [">=0.8.0", "<2.0.0"]


### PR DESCRIPTION
### Changes
- The maximum required version of dbt_utils is changed from 1.0.0. 