### PR TITLE
Fix ghost records derived datatypes

### DIFF
--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -341,7 +341,7 @@ unknown_values AS (
     {%- if datavault4dbt.is_something(derived_columns) -%},
     {# Additionally generating Ghost Records for Derived Columns #}
       {%- for column_name, properties in derived_columns_with_datatypes_DICT.items() %}
-        {{ datavault4dbt.ghost_record_per_datatype(column_name=column_name, datatype=properties.datatype, ghost_record_type='unknown') }}
+        {{ datavault4dbt.ghost_record_per_datatype(column_name=column_name, datatype=properties.datatype, col_size=properties.col_size, ghost_record_type='unknown') }}
         {%- if not loop.last %},{% endif -%}
       {%- endfor -%}
 
@@ -402,7 +402,7 @@ error_values AS (
     {%- if datavault4dbt.is_something(derived_columns) %},
     {# Additionally generating Ghost Records for Derived Columns #}
       {%- for column_name, properties in derived_columns_with_datatypes_DICT.items() %}
-        {{ datavault4dbt.ghost_record_per_datatype(column_name=column_name, datatype=properties.datatype, ghost_record_type='error') }}
+        {{ datavault4dbt.ghost_record_per_datatype(column_name=column_name, datatype=properties.datatype, col_size=properties.col_size, ghost_record_type='error') }}
         {%- if not loop.last %},{% endif %}
       {%- endfor -%}
 

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -131,10 +131,30 @@
 {%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+{%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
+{%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
+{%- set unknown_value_alt__STRING = var('datavault4dbt.unknown_value_alt__STRING', 'u')  -%}
+{%- set error_value_alt__STRING = var('datavault4dbt.error_value_alt__STRING', 'e')  -%}
 
 {%- if ghost_record_type == 'unknown' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }} AS {{ column_name }}
-     {% elif datatype in ['STRING','VARCHAR'] %}'(unknown)' AS {{ column_name }}
+     {% elif datatype in ['STRING', 'VARCHAR'] %}'(unknown)' AS {{ column_name }}
+     {%- elif datatype.upper().startswith('VARCHAR(') -%}
+            {%- if col_size is not none -%}
+                {%- set unknown_dtype_length = col_size | int -%}
+                {%- if '(' not in datatype -%}
+                    {%- set datatype = datatype ~ "(" ~ (unknown_dtype_length|string) ~ ")" -%}
+                {%- endif -%}
+            {%- else -%}
+                {%- set inside_parenthesis =  datatype.split(")")[0] |string -%}
+                {%- set inside_parenthesis = inside_parenthesis.split("(")[1]-%}
+                {%- set unknown_dtype_length = inside_parenthesis | int -%}
+            {%- endif -%}
+            {%- if unknown_dtype_length < unknown_value__STRING|length -%}
+                CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
+            {%- else -%}
+                CAST('{{ unknown_value__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
+            {%- endif -%}
      {% elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}0 AS {{ column_name }}
      {% elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ column_name }}
      {% else %}NULL AS {{ column_name }}
@@ -142,6 +162,22 @@
 {%- elif ghost_record_type == 'error' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }} AS {{ column_name }}
      {% elif datatype in ['STRING','VARCHAR'] %}'(error)' AS {{ column_name }}
+     {%- elif datatype.upper().startswith('VARCHAR(') -%}
+            {%- if col_size is not none -%}
+                {%- set error_dtype_length = col_size | int -%}
+                {%- if '(' not in datatype -%}
+                    {%- set datatype = datatype ~ "(" ~ (error_dtype_length|string) ~ ")" -%}
+                {%- endif -%}
+            {%- else -%}
+                {%- set inside_parenthesis =  datatype.split(")")[0] |string -%}
+                {%- set inside_parenthesis = inside_parenthesis.split("(")[1]-%}
+                {%- set error_dtype_length = inside_parenthesis | int -%}
+            {%- endif -%}
+            {%- if error_dtype_length < error_value__STRING|length  -%}
+                CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
+            {%- else -%}
+                CAST('{{ error_value__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
+            {%- endif -%}
      {% elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}-1 AS {{ column_name }}
      {% elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ column_name }}
      {% else %}NULL AS {{ column_name }}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -138,8 +138,9 @@
 
 {%- if ghost_record_type == 'unknown' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }} AS {{ column_name }}
-     {% elif datatype in ['STRING', 'VARCHAR'] %}'(unknown)' AS {{ column_name }}
-     {%- elif datatype.upper().startswith('VARCHAR(') -%}
+     {%- elif datatype in ['STRING', 'VARCHAR'] %}'{{ unknown_value__STRING }}' AS {{ column_name }}
+     {%- elif datatype == 'CHAR' %}CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
+     {%- elif datatype.upper().startswith('VARCHAR(') or datatype.upper().startswith('CHAR(') -%}
             {%- if col_size is not none -%}
                 {%- set unknown_dtype_length = col_size | int -%}
                 {%- if '(' not in datatype -%}
@@ -155,14 +156,15 @@
             {%- else -%}
                 CAST('{{ unknown_value__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
             {%- endif -%}
-     {% elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}0 AS {{ column_name }}
-     {% elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ column_name }}
-     {% else %}NULL AS {{ column_name }}
+     {%- elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}0 AS {{ column_name }}
+     {%- elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ column_name }}
+     {%- else %}NULL AS {{ column_name }}
      {% endif %}
 {%- elif ghost_record_type == 'error' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }} AS {{ column_name }}
-     {% elif datatype in ['STRING','VARCHAR'] %}'(error)' AS {{ column_name }}
-     {%- elif datatype.upper().startswith('VARCHAR(') -%}
+     {%- elif datatype in ['STRING','VARCHAR'] %}'{{ error_value__STRING }}' AS {{ column_name }}
+     {%- elif datatype == 'CHAR' %}CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as "{{ column_name }}"
+     {%- elif datatype.upper().startswith('VARCHAR(')  or datatype.upper().startswith('CHAR(') -%}
             {%- if col_size is not none -%}
                 {%- set error_dtype_length = col_size | int -%}
                 {%- if '(' not in datatype -%}


### PR DESCRIPTION
### Fixed ghost records for derived column VARCHAR datatype - Snowflake

- In the macro **snowflake__ghost_record_per_datatype** the length of the column is now taken into consideration if the column is of type VARCHAR or CHAR with specified char size(length). If the source column has length smaller than the length of the string unknown/error value datavault4dbt.error_value__STRING/datavault4dbt.unknown_value__STRING (both configured in dbt_project.yml) then it sets the ghost record with the alternative value for STRING, also configured in dbt_project.yml under the variables datavault4dbt.unknown_value_alt__STRING/datavault4dbt.error_value_alt__STRING

- In Snowflake **Stage** macro the col_size is now passed as an argument to datavault4dbt.ghost_record_per_datatype to account for the length for generating the unknown and error values for derived columns.

This feature was already present in Exasol but I noticed was not present in Snowflake adapter version.