### PR TITLE
Hotfix rsrs static query performance

### DIFF
--- a/macros/tables/bigquery/hub.sql
+++ b/macros/tables/bigquery/hub.sql
@@ -80,6 +80,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -89,6 +90,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -104,13 +106,21 @@ WITH
                 {%- endfor -%}
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
-
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
+            
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
+
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 

--- a/macros/tables/bigquery/nh_link.sql
+++ b/macros/tables/bigquery/nh_link.sql
@@ -5,10 +5,10 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
-
 {%- if source_models is not mapping -%}
     {%- set source_models = {source_models: {}} -%}
 {%- endif -%}
@@ -78,6 +78,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -87,6 +88,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -102,12 +104,19 @@ WITH
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
 
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 

--- a/macros/tables/exasol/hub.sql
+++ b/macros/tables/exasol/hub.sql
@@ -80,6 +80,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT {{ this }}.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -89,6 +90,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -104,13 +106,21 @@ WITH
                 {%- endfor -%}
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
-
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
+            
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
+
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 

--- a/macros/tables/exasol/link.sql
+++ b/macros/tables/exasol/link.sql
@@ -83,6 +83,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT {{ this }}.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -92,6 +93,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -107,12 +109,19 @@ WITH
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
 
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 

--- a/macros/tables/snowflake/hub.sql
+++ b/macros/tables/snowflake/hub.sql
@@ -80,6 +80,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -89,6 +90,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -104,13 +106,21 @@ WITH
                 {%- endfor -%}
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
-
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
+            
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
+
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 

--- a/macros/tables/snowflake/link.sql
+++ b/macros/tables/snowflake/link.sql
@@ -83,6 +83,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -92,6 +93,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -107,12 +109,19 @@ WITH
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
 
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 

--- a/macros/tables/snowflake/nh_link.sql
+++ b/macros/tables/snowflake/nh_link.sql
@@ -78,6 +78,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_model] -%}
 
             {%- set rsrc_static_query_source -%}
+                SELECT count(*) FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT {{ this }}.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static
@@ -87,6 +88,7 @@ WITH
                         UNION ALL
                     {% endif -%}
                 {%- endfor -%}
+                )
             {% endset %}
 
             rsrc_static_{{ source_number }} AS (
@@ -102,12 +104,19 @@ WITH
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
 
-            {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
             {%- set source_in_target = true -%}
+            
+            {%- if execute -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
-            {% if not rsrc_static_result %}
-                {%- set source_in_target = false -%}
-            {% endif %}
+                {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
+
+                {{ log('row_count for '~source_model~' is '~row_count, false) }}
+
+                {%- if row_count == 0 -%}
+                    {%- set source_in_target = false -%}
+                {%- endif -%}
+            {%- endif -%}
 
             {%- do ns.source_included_before.update({source_model: source_in_target}) -%}
 


### PR DESCRIPTION
## Error
- In dbt Cloud, during an execution of "dbt build" or "dbt docs generate", the Job failed with the error message "This run exceeded your account's run memory limits."
- Occured for Multi Source Entities in incremental runs
## Cause of Error
- The background code checks for each source if it was included before, to disable the high-water-mark in such a case for this newly added source
- Here all the rows of each source are loaded into dbt and set as a variable
- With high volumes of data, this variable grows very big and therefore the account's memory is exceeded
## Fix
- Instead of selecting all rows for each source, only a COUNT(*) is executed. This works fine, because later on the query results are only used to check if there are any rows, not to actually do something with the data. 
- This change is applied for all multi-source entities (Hubs, Links, NH-Links, Rec-Track Satellites), for all databases