### PR TITLE
Added macro for hash method

### DIFF
--- a/macros/staging/bigquery/stage.sql
+++ b/macros/staging/bigquery/stage.sql
@@ -136,7 +136,7 @@
 {#- Select hashing algorithm -#}
 
 {#- Setting unknown and error keys with default values for the selected hash algorithm -#}
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -138,7 +138,7 @@
 {#- Select hashing algorithm -#}
 
 {#- Setting unknown and error keys with default values for the selected hash algorithm -#}
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'HASHTYPE') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}

--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -136,7 +136,7 @@
 {#- Select hashing algorithm -#}
 
 {#- Setting unknown and error keys with default values for the selected hash algorithm -#}
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {{ log('hash_function: ' ~ hash, false)}}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -53,7 +53,7 @@
 {%- set unknown_value_alt__STRING = var('datavault4dbt.unknown_value_alt__STRING', 'u')  -%}
 {%- set error_value_alt__STRING = var('datavault4dbt.error_value_alt__STRING', 'e')  -%}
 {%- set format_date = var('datavault4dbt.format_date', 'YYYY-mm-dd') -%}
-{%- set hash = var('datavault4dbt.hash', 'MD5')-%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_default_values =  datavault4dbt.hash_default_values(hash_function=hash) -%}
 {%- set hash_alg= hash_default_values['hash_alg'] -%}
 {%- set unknown_value__HASHTYPE = hash_default_values['unknown_key'] -%}

--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -15,7 +15,7 @@
 
 {%- macro default__hash(columns, alias, is_hashdiff, multi_active_key, main_hashkey_column) -%}
 
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set concat_string = var('concat_string', '||') -%}
 {%- set quote = var('quote', '"') -%}
 {%- set null_placeholder_string = var('null_placeholder_string', '^^') -%}
@@ -83,7 +83,7 @@
 
 {%- macro exasol__hash(columns, alias, is_hashdiff, multi_active_key, main_hashkey_column) -%}
 
-    {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+    {%- set hash = datavault4dbt.hash_method() -%}
     {%- set concat_string = var('concat_string', '||') -%}
     {%- set quote = var('quote', '"') -%}
     {%- set null_placeholder_string = var('null_placeholder_string', '^^') -%}

--- a/macros/supporting/hash_method.sql
+++ b/macros/supporting/hash_method.sql
@@ -1,0 +1,80 @@
+{%- macro hash_method() %}
+
+    {{ return( adapter.dispatch('hash_method', 'datavault4dbt')() ) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__hash_method() %}
+
+{%- set global_var = var('datavault4dbt.hash', none) -%}
+{%- set hash_method = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'bigquery' in global_var.keys()|map('lower') -%}
+        {% set hash_method = global_var['bigquery'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.hash' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set hash_method = 'MD5' -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set hash_method = global_var -%}
+{%- else -%}
+    {%- set hash_method = 'MD5' -%}
+{%- endif -%}
+
+{{ return(hash_method) }}
+
+{%- endmacro -%}
+
+
+{%- macro snowflake__hash_method() %}
+
+{%- set global_var = var('datavault4dbt.hash', none) -%}
+{%- set hash_method = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'snowflake' in global_var.keys()|map('lower') -%}
+        {% set hash_method = global_var['snowflake'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.hash' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set hash_method = 'MD5' -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set hash_method = global_var -%}
+{%- else -%}
+    {%- set hash_method = 'MD5' -%}
+{%- endif -%}
+
+{{ return(hash_method) }}
+
+{%- endmacro -%}
+
+
+{%- macro exasol__hash_method() %}
+
+{%- set global_var = var('datavault4dbt.hash', none) -%}
+{%- set hash_method = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'exasol' in global_var.keys()|map('lower') -%}
+        {% set hash_method = global_var['exasol'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.hash' to a dictionary, but have not included the adapter you use (exasol) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set hash_method = 'MD5' -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set hash_method = global_var -%}
+{%- else -%}
+    {%- set hash_method = 'MD5' -%}
+{%- endif -%}
+
+{{ return(hash_method) }}
+
+{%- endmacro -%}

--- a/macros/tables/bigquery/pit.sql
+++ b/macros/tables/bigquery/pit.sql
@@ -1,6 +1,6 @@
 {%- macro default__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
 
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}

--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -1,6 +1,6 @@
 {%- macro exasol__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
 
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'HASHTYPE') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}

--- a/macros/tables/snowflake/pit.sql
+++ b/macros/tables/snowflake/pit.sql
@@ -1,6 +1,6 @@
 {%- macro snowflake__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
 
-{%- set hash = var('datavault4dbt.hash', 'MD5') -%}
+{%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}


### PR DESCRIPTION
Added the macro hash_method that dispatches the adapters and has a similar logic to the datavault4dbt.beginning_of_all_times and datavault4dbt.end_of_all_times macros.
Replaced the use of var('datavault4dbt.hash') with the macro call in other macros.