### PR TITLE
Feature 1136 prejoin flexibility

### DIFF
--- a/macros/internal/helpers/stage_processing_macros.sql
+++ b/macros/internal/helpers/stage_processing_macros.sql
@@ -54,7 +54,13 @@
             {%- elif value is mapping and value.is_hashdiff -%}
                 {%- do extracted_input_columns.append(value['columns']) -%}
             {%- elif value is mapping and 'this_column_name' in value.keys() -%}
-                {%- do extracted_input_columns.append(value['this_column_name']) -%}
+                {%- if datavault4dbt.is_list(value['this_column_name'])-%}
+                    {%- for column in value['this_column_name'] -%}
+                        {%- do extracted_input_columns.append(column) -%}
+                    {%- endfor -%}
+                {%- else -%}
+                    {%- do extracted_input_columns.append(value['this_column_name']) -%}
+                {%- endif -%}
             {%- else -%}
                 {%- do extracted_input_columns.append(value) -%}
             {%- endif -%}

--- a/macros/internal/metadata_processing/multikey.sql
+++ b/macros/internal/metadata_processing/multikey.sql
@@ -1,10 +1,10 @@
 {%- macro multikey(columns, prefix=none, condition=none, operator='AND', right_columns=none) -%}
 
-    {{- adapter.dispatch('multikey', 'datavault4dbt')(columns=columns, prefix=prefix, condition=condition, operator=operator) -}}
+    {{- adapter.dispatch('multikey', 'datavault4dbt')(columns=columns, prefix=prefix, condition=condition, operator=operator, right_columns=right_columns) -}}
 
 {%- endmacro %}
 
-{%- macro default__multikey(columns, prefix=none, condition=none, operator='AND') -%}
+{%- macro default__multikey(columns, prefix=none, condition=none, operator='AND', right_columns=none) -%}
 
     {%- if prefix is string -%}
         {%- set prefix = [prefix] -%}
@@ -32,7 +32,7 @@
     {%- if condition in ['<>', '!=', '='] -%}
         {%- for col in columns -%}
             {%- if prefix -%}
-                {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition }} {{ datavault4dbt.prefix([right_column[loop.index0]], prefix[1]) -}}
+                {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition }} {{ datavault4dbt.prefix([right_columns[loop.index0]], prefix[1]) -}}
             {%- endif %}
             {%- if not loop.last %} {{ operator }} {% endif -%}
         {% endfor -%}

--- a/macros/internal/metadata_processing/multikey.sql
+++ b/macros/internal/metadata_processing/multikey.sql
@@ -18,7 +18,7 @@
         {%- set right_columns = columns -%}
     {%- elif right_columns is string -%}
         {%- set right_columns = [right_columns] -%}
-    {%- elif right_columns|length <> columns|length -%}
+    {%- elif right_columns|length != columns|length -%}
         {%- set error_message -%}
       Multikey Error: If right_columns are defined, it must be the same length as columns. 
       Got: 
@@ -26,7 +26,7 @@
         right_columns: {{ right_columns }} with length {{ right_columns|length }}
         {%- endset -%}
 
-        {{- do exceptions.raise_compiler_error(error_message) -}}
+        {{- exceptions.raise_compiler_error(error_message) -}}
     {%- endif -%}
 
     {%- if condition in ['<>', '!=', '='] -%}

--- a/macros/internal/metadata_processing/multikey.sql
+++ b/macros/internal/metadata_processing/multikey.sql
@@ -1,4 +1,4 @@
-{%- macro multikey(columns, prefix=none, condition=none, operator='AND') -%}
+{%- macro multikey(columns, prefix=none, condition=none, operator='AND', right_columns=none) -%}
 
     {{- adapter.dispatch('multikey', 'datavault4dbt')(columns=columns, prefix=prefix, condition=condition, operator=operator) -}}
 
@@ -14,10 +14,25 @@
         {%- set columns = [columns] -%}
     {%- endif -%}
 
+    {%- if right_columns is none -%}
+        {%- set right_columns = columns -%}
+    {%- elif right_columns is string -%}
+        {%- set right_columns = [right_columns] -%}
+    {%- elif right_columns|length <> columns|length -%}
+        {%- set error_message -%}
+      Multikey Error: If right_columns are defined, it must be the same length as columns. 
+      Got: 
+        Columns: {{ columns }} with length {{ columns|length }}
+        right_columns: {{ right_columns }} with length {{ right_columns|length }}
+        {%- endset -%}
+
+        {{- do exceptions.raise_compiler_error(error_message) -}}
+    {%- endif -%}
+
     {%- if condition in ['<>', '!=', '='] -%}
         {%- for col in columns -%}
             {%- if prefix -%}
-                {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition }} {{ datavault4dbt.prefix([col], prefix[1]) -}}
+                {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition }} {{ datavault4dbt.prefix([right_column[loop.index0]], prefix[1]) -}}
             {%- endif %}
             {%- if not loop.last %} {{ operator }} {% endif -%}
         {% endfor -%}

--- a/macros/staging/bigquery/stage.sql
+++ b/macros/staging/bigquery/stage.sql
@@ -227,8 +227,50 @@ prejoined_columns AS (
 
   FROM {{ last_cte }} lcte
 
-  {%- for col, vals in prejoined_columns.items() %}
-    left join {{ source(vals['src_name']|string, vals['src_table']) }} as pj_{{loop.index}} on lcte.{{ vals['this_column_name'] }} = pj_{{loop.index}}.{{ vals['ref_column_name'] }}
+  {% for col, vals in prejoined_columns.items() %}
+
+    {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
+      {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
+    {%- elif 'ref_model' in vals.keys() -%}
+      {%- set relation = ref(vals['ref_model']) -%}
+    {%- else -%}
+      {%- set error_message -%}
+      Prejoin error: Invalid target entity definition. Allowed are: 
+      e.g.
+      [REF STYLE]
+      extracted_column_alias:
+        ref_model: model_name
+        bk: extracted_column_name
+        this_column_name: join_columns_in_this_model
+        ref_column_name: join_columns_in_ref_model
+      OR
+      [SOURCES STYLE]
+      extracted_column_alias:
+        src_name: name_of_ref_source
+        src_table: name_of_ref_table
+        bk: extracted_column_name
+        this_column_name: join_columns_in_this_model
+        ref_column_name: join_columns_in_ref_model
+
+      Got: 
+      {{ col }}: {{ vals }}
+      {%- endset -%}
+
+    {%- do exceptions.raise_compiler_error(error_message) -%}
+    {%- endif -%}
+
+{# This sets a default value for the operator that connects multiple joining conditions. Only when it is not set by user. #}
+    {%- if 'operator' not in vals.keys() -%}
+      {%- set operator = 'AND' -%}
+    {%- else -%}
+      {%- set operator = vals['operator'] -%}
+    {%- endif -%}
+
+    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
+
+    left join {{ relation }} as {{ prejoin_alias }} 
+      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
   {% endfor %}
 
   {% set last_cte = "prejoined_columns" -%}
@@ -372,7 +414,13 @@ unknown_values AS (
     {# Additionally generating ghost records for the prejoined attributes#}
       {% for col, vals in prejoined_columns.items() %}
 
-        {%- set pj_relation_columns = adapter.get_columns_in_relation( source(vals['src_name']|string, vals['src_table']) ) -%}
+        {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
+          {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
+        {%- elif 'ref_model' in vals.keys() -%}
+          {%- set relation = ref(vals['ref_model']) -%}
+        {%- endif -%}
+
+        {%- set pj_relation_columns = adapter.get_columns_in_relation( relation ) -%}
 
           {% for column in pj_relation_columns -%}
 
@@ -434,7 +482,13 @@ error_values AS (
     {# Additionally generating ghost records for the prejoined attributes #}
       {%- for col, vals in prejoined_columns.items() %}
 
-        {%- set pj_relation_columns = adapter.get_columns_in_relation( source(vals['src_name']|string, vals['src_table']) ) -%}
+        {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
+          {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
+        {%- elif 'ref_model' in vals.keys() -%}
+          {%- set relation = ref(vals['ref_model']) -%}
+        {%- endif -%}
+
+        {%- set pj_relation_columns = adapter.get_columns_in_relation( relation ) -%}
 
         {% for column in pj_relation_columns -%}
           {% if column.name|lower == vals['bk']|lower -%}

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -229,8 +229,50 @@ prejoined_columns AS (
 
   FROM {{ last_cte }} lcte
 
-  {%- for col, vals in prejoined_columns.items() %}
-    left join {{ source(vals['src_name']|string, vals['src_table']) }} as pj_{{loop.index}} on lcte.{{ vals['this_column_name'] }} = pj_{{loop.index}}.{{ vals['ref_column_name'] }}
+  {% for col, vals in prejoined_columns.items() %}
+
+    {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
+      {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
+    {%- elif 'ref_model' in vals.keys() -%}
+      {%- set relation = ref(vals['ref_model']) -%}
+    {%- else -%}
+      {%- set error_message -%}
+      Prejoin error: Invalid target entity definition. Allowed are: 
+      e.g.
+      [REF STYLE]
+      extracted_column_alias:
+        ref_model: model_name
+        bk: extracted_column_name
+        this_column_name: join_columns_in_this_model
+        ref_column_name: join_columns_in_ref_model
+      OR
+      [SOURCES STYLE]
+      extracted_column_alias:
+        src_name: name_of_ref_source
+        src_table: name_of_ref_table
+        bk: extracted_column_name
+        this_column_name: join_columns_in_this_model
+        ref_column_name: join_columns_in_ref_model
+
+      Got: 
+      {{ col }}: {{ vals }}
+      {%- endset -%}
+
+    {%- do exceptions.raise_compiler_error(error_message) -%}
+    {%- endif -%}
+
+{# This sets a default value for the operator that connects multiple joining conditions. Only when it is not set by user. #}
+    {%- if 'operator' not in vals.keys() -%}
+      {%- set operator = 'AND' -%}
+    {%- else -%}
+      {%- set operator = vals['operator'] -%}
+    {%- endif -%}
+
+    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
+
+    left join {{ relation }} as {{ prejoin_alias }} 
+      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
   {% endfor %}
 
   {% set last_cte = "prejoined_columns" -%}
@@ -373,7 +415,13 @@ unknown_values AS (
     {# Additionally generating ghost records for the prejoined attributes#}
       {% for col, vals in prejoined_columns.items() %}
 
-        {%- set pj_relation_columns = adapter.get_columns_in_relation( source(vals['src_name']|string, vals['src_table']) ) -%}
+        {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
+          {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
+        {%- elif 'ref_model' in vals.keys() -%}
+          {%- set relation = ref(vals['ref_model']) -%}
+        {%- endif -%}
+
+        {%- set pj_relation_columns = adapter.get_columns_in_relation( relation ) -%}
 
           {% for column in pj_relation_columns -%}
 
@@ -435,7 +483,13 @@ error_values AS (
     {# Additionally generating ghost records for the prejoined attributes #}
       {%- for col, vals in prejoined_columns.items() %}
 
-        {%- set pj_relation_columns = adapter.get_columns_in_relation( source(vals['src_name']|string, vals['src_table']) ) -%}
+        {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
+          {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
+        {%- elif 'ref_model' in vals.keys() -%}
+          {%- set relation = ref(vals['ref_model']) -%}
+        {%- endif -%}
+
+        {%- set pj_relation_columns = adapter.get_columns_in_relation( relation ) -%}
 
         {% for column in pj_relation_columns -%}
           {% if column.name|lower == vals['bk']|lower -%}

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -224,7 +224,7 @@ prejoined_columns AS (
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
   {% endif %}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS "{{ col }}"
+    ,pj_{{loop.index}}.{{ vals['bk'] }} AS "{{ col | upper }}"
   {% endfor -%}
 
   FROM {{ last_cte }} lcte
@@ -422,11 +422,9 @@ unknown_values AS (
         {%- endif -%}
 
         {%- set pj_relation_columns = adapter.get_columns_in_relation( relation ) -%}
-
           {% for column in pj_relation_columns -%}
-
             {% if column.name|lower == vals['bk']|lower -%}
-              {{ datavault4dbt.ghost_record_per_datatype(column_name=col, datatype=column.dtype, col_size=column.char_size, ghost_record_type='unknown') }}
+              {{ datavault4dbt.ghost_record_per_datatype(column_name=col|upper, datatype=column.dtype, col_size=column.char_size, ghost_record_type='unknown') }}
             {%- endif -%}
 
           {%- endfor -%}
@@ -493,7 +491,7 @@ error_values AS (
 
         {% for column in pj_relation_columns -%}
           {% if column.name|lower == vals['bk']|lower -%}
-            {{ datavault4dbt.ghost_record_per_datatype(column_name=col, datatype=column.dtype, col_size=column.char_size, ghost_record_type='error') -}}
+            {{ datavault4dbt.ghost_record_per_datatype(column_name=col|upper, datatype=column.dtype, col_size=column.char_size, ghost_record_type='error') -}}
           {%- endif -%}
         {%- endfor -%}
           {%- if not loop.last -%},{%- endif %}

--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -257,7 +257,7 @@ prejoined_columns AS (
       {{ col }}: {{ vals }}
       {%- endset -%}
 
-    {{- do exceptions.raise_compiler_error(error_message) -}}
+    {%- do exceptions.raise_compiler_error(error_message) -%}
     {%- endif -%}
 
     {%- set operator = vals['operator'] -%}

--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -71,10 +71,9 @@
                                                                 'bk': 'contractnumber',                     name (specified in 'bk') from the source table 'contract' in the source 'source_data'
                                                                 'this_column_name': 'ContractId',           by joining on 'this.ContractId = contract.Id'. In this case the prejoined
                                                                 'ref_column_name': 'Id'},                   column alias equals the name of the original business key column, which should be
-                                            'master_account_key' {'src_name': 'source_data',                the case for most prejoins. But sometimes the same object is prejoined multiple times
-                                                                'src_table': 'account',                     or a self-prejoin happens, and then you would have to rename the final columns to not
+                                            'master_account_key' {'ref_model': 'account_prep',              or a self-prejoin happens, and then you would have to rename the final columns to not
                                                                 'bk': 'account_key',                        have duplicate column names. The column 'master_account_key' holds values of the column
-                                                                'this_column_name': 'master_account_id',    'account_key' inside the source table 'account'. If this prejoin is done inside account,
+                                                                'this_column_name': 'master_account_id',    'account_key' inside the pre-populated dbt model 'account_prep'. If this prejoin is done inside account,
                                                                 'ref_column_name': 'Id'}}                   we would now have a self-prejoin ON 'account.master_account_id = account.Id'. Because
                                                                                                             the table 'account' already has a column 'account_key', we rename the prejoined column
                                                                                                             to 'master_account_key'. More prejoined columns can be added as other keys of the dictionary.


### PR DESCRIPTION
# Changes
## Stages (prejoins)
- Instead of prejoining to another dbt source, the parameter "ref_model" can be used instead of "src_name" & "src_table", to prejoin with other dbt models
- the parameters "this_column_name" & "ref_column_name" can now be set to a list of columns. Important: both need to have the same number of columns
  - By default, these multiple join conditions are combined with an "AND". You can set another operator by adding the parameter "operator" to a prejoined column definition. 