### PR TITLE
Added datatype "ARRAY" for Ghost Records Snowflake

### DIFF
--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -166,6 +166,7 @@
             {%- endif -%}
      {%- elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}0 AS {{ alias }}
      {%- elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ alias }}
+     {%- elif datatype == 'ARRAY' %} CAST('{{ unknown_value__STRING }}' as ARRAY) as {{ column_name }}
      {%- else %}NULL AS {{ alias }}
      {% endif %}
 {%- elif ghost_record_type == 'error' -%}
@@ -190,6 +191,7 @@
             {%- endif -%}
      {% elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}-1 AS {{ alias }}
      {% elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ alias }}
+     {% elif datatype == 'ARRAY' %} CAST('{{ error_value__STRING }}' as ARRAY) as {{ column_name }}
      {% else %}NULL AS {{ alias }}
       {% endif %}
 {%- else -%}


### PR DESCRIPTION
Added supported datatype "ARRAY" to the Ghost Records for the Snowflake Adapter