### PR TITLE
Extended log logic of snapshot control tables

### DIFF
--- a/macros/tables/bigquery/control_snap_v0.sql
+++ b/macros/tables/bigquery/control_snap_v0.sql
@@ -54,10 +54,22 @@ enriched_timestamps AS (
             WHEN EXTRACT(DAY FROM sdts) = 1 THEN TRUE
             ELSE FALSE
         END as is_monthly,
+        CASE 
+            WHEN LAST_DAY(sdts, 'month') = DATE(sdts) THEN TRUE
+            ELSE FALSE
+        END as is_end_of_monthly,
+        CASE
+            WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH from sdts) IN (1,4,7,10) THEN TRUE
+            ELSE FALSE
+        END AS is_quarterly,
         CASE
             WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH FROM sdts) = 1 THEN TRUE
             ELSE FALSE
         END as is_yearly,
+        CASE
+            WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
+            ELSE FALSE
+        END AS is_end_of_yearly,
         NULL as comment
     FROM initial_timestamps
 

--- a/macros/tables/bigquery/control_snap_v0.sql
+++ b/macros/tables/bigquery/control_snap_v0.sql
@@ -57,7 +57,7 @@ enriched_timestamps AS (
         CASE 
             WHEN LAST_DAY(sdts, 'month') = DATE(sdts) THEN TRUE
             ELSE FALSE
-        END as is_end_of_monthly,
+        END as is_end_of_month,
         CASE
             WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH from sdts) IN (1,4,7,10) THEN TRUE
             ELSE FALSE
@@ -69,7 +69,7 @@ enriched_timestamps AS (
         CASE
             WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
             ELSE FALSE
-        END AS is_end_of_yearly,
+        END AS is_end_of_year,
         NULL as comment
     FROM initial_timestamps
 

--- a/macros/tables/bigquery/control_snap_v1.sql
+++ b/macros/tables/bigquery/control_snap_v1.sql
@@ -98,20 +98,20 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif -%}
 
-            {%- if 'end_of_monthly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+            {%- if 'end_of_month' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
-                {%- if log_logic['end_of_monthly']['forever'] is true -%}
+                {%- if log_logic['end_of_month']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' -%}
-                    (c.is_end_of_monthly = TRUE)
+                    (c.is_end_of_month = TRUE)
                 {%- else %}
 
-                    {%- set end_of_monthly_duration = log_logic['end_of_monthly']['duration'] -%}
-                    {%- set end_of_monthly_unit = log_logic['end_of_monthly']['unit'] -%}
+                    {%- set end_of_month_duration = log_logic['end_of_month']['duration'] -%}
+                    {%- set end_of_month_unit = log_logic['end_of_month']['unit'] -%}
 
                     (
-                (EXTRACT(DATE FROM c.{{ sdts_alias }}) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL {{ end_of_monthly_duration }} {{ end_of_monthly_unit }}) AND CURRENT_DATE() )
+                (EXTRACT(DATE FROM c.{{ sdts_alias }}) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL {{ end_of_month_duration }} {{ end_of_month_unit }}) AND CURRENT_DATE() )
                 AND
-                (c.is_end_of_monthly = TRUE)
+                (c.is_end_of_month = TRUE)
             )
                 {%- endif -%}
             {% endif -%}
@@ -152,20 +152,20 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif %}
 
-            {%- if 'end_of_yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+            {%- if 'end_of_year' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
-                {%- if log_logic['end_of_yearly']['forever'] is true -%}
+                {%- if log_logic['end_of_year']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' -%}
-                    (c.is_end_of_yearly = TRUE)
+                    (c.is_end_of_year = TRUE)
                 {%- else %}
 
-                    {%- set end_of_yearly_duration = log_logic['end_of_yearly']['duration'] -%}
-                    {%- set end_of_yearly_unit = log_logic['end_of_yearly']['unit'] -%}
+                    {%- set end_of_year_duration = log_logic['end_of_year']['duration'] -%}
+                    {%- set end_of_year_unit = log_logic['end_of_year']['unit'] -%}
 
                     (
-                (EXTRACT(DATE FROM c.{{ sdts_alias }}) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL {{ end_of_yearly_duration }} {{ end_of_yearly_unit }}) AND CURRENT_DATE() )
+                (EXTRACT(DATE FROM c.{{ sdts_alias }}) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL {{ end_of_year_duration }} {{ end_of_year_unit }}) AND CURRENT_DATE() )
                 AND
-                (c.is_end_of_yearly = TRUE)
+                (c.is_end_of_year = TRUE)
             )
                 {%- endif -%}
             {% endif %}
@@ -185,10 +185,10 @@ virtual_logic AS (
         c.is_daily,
         c.is_weekly,
         c.is_monthly,
-        c.is_end_of_monthly,
+        c.is_end_of_month,
         c.is_quarterly,
         c.is_yearly,
-        c.is_end_of_yearly,
+        c.is_end_of_year,
         CASE
             WHEN EXTRACT(YEAR FROM c.{{ sdts_alias }}) = EXTRACT(YEAR FROM CURRENT_DATE()) THEN TRUE
             ELSE FALSE
@@ -227,10 +227,10 @@ active_logic_combined AS (
         is_daily,
         is_weekly,
         is_monthly,
-        is_end_of_monthly,
+        is_end_of_month,
         is_quarterly,
         is_yearly,
-        is_end_of_yearly,
+        is_end_of_year,
         is_current_year,
         is_last_year,
         is_rolling_year,

--- a/macros/tables/control_snap_v0.sql
+++ b/macros/tables/control_snap_v0.sql
@@ -28,13 +28,13 @@
 
         is_monthly::boolean             Captures if a sdts is the first day of a month.
 
-        is_end_of_monthly::boolean      Captures if a sdts is the last day of a month.
+        is_end_of_month::boolean      Captures if a sdts is the last day of a month.
 
         is_quarterly::boolean           Captures if a sdts is the first day of a quarter.
 
         is_yearly::boolean              Captures if a sdts is the first day of a year.
 
-        is_end_of_yearly::boolean       Captures if a sdts is the last day of a year.
+        is_end_of_year::boolean       Captures if a sdts is the last day of a year.
 
         comment::string                 Allows users to write custom comments for each sdts. By default this column is set to NULL.
         

--- a/macros/tables/control_snap_v0.sql
+++ b/macros/tables/control_snap_v0.sql
@@ -28,14 +28,16 @@
 
         is_monthly::boolean             Captures if a sdts is the first day of a month.
 
+        is_end_of_monthly::boolean      Captures if a sdts is the last day of a month.
+
+        is_quarterly::boolean           Captures if a sdts is the first day of a quarter.
+
         is_yearly::boolean              Captures if a sdts is the first day of a year.
+
+        is_end_of_yearly::boolean       Captures if a sdts is the last day of a year.
 
         comment::string                 Allows users to write custom comments for each sdts. By default this column is set to NULL.
         
-        force_active::boolean           Allows users to deactivate single snapshots. Deactivating a snapshot here overwrites any logarithmic
-                                        logic that is applied in the version 1 snapshot table on top of this one. This column is automatically
-                                        set to TRUE.
-
         force_active::boolean           Allows users to deactivate single snapshots. Deactivating a snapshot here overwrites any logarithmic
                                         logic that is applied in the version 1 snapshot table on top of this one. This column is automatically
                                         set to TRUE.

--- a/macros/tables/control_snap_v1.sql
+++ b/macros/tables/control_snap_v1.sql
@@ -33,8 +33,9 @@
                                             available as a dbt model.
 
         log_logic::dictionary               Defining the desired durations of each granularity. Available granularities
-                                            are 'daily', 'weekly', 'monthly', and 'yearly'. For each granularity the
-                                            duration can be defined as an integer, and the time unit for that duration.
+                                            are 'daily', 'weekly', 'monthly', 'end_of_monthly', 'quarterly', 'yearly'
+                                            and 'end_of_yearly'. For each granularity the duration can be defined as an 
+                                            integer, and the time unit for that duration.
                                             The units include (in BigQuery): DAY, WEEK, MONTH, QUARTER, YEAR. Besides
                                             defining a duration and a unit for each granularity, there is also the option
                                             to set a granularity to 'forever'. E.g. reporting requires daily snapshots
@@ -44,9 +45,6 @@
                                             active. The other dynamic columns are calculated anyway.
 
                                             The duration is always counted from the current date.
-
-                                            EXASOL: Due to a missing "DAY OF WEEK" Function in Exasol, is_weekly is currently
-                                                    not supported and needs to be left out of the log_logic definition.
 
                                             Examples:
                                                 {'daily': {'duration': 3,               This configuration would keep daily

--- a/macros/tables/exasol/control_snap_v0.sql
+++ b/macros/tables/exasol/control_snap_v0.sql
@@ -60,7 +60,7 @@ initial_timestamps AS
         CASE
             WHEN sdts = date_add('day', -1, date_add('month', 1, date_trunc('month', sdts))) THEN TRUE
             ELSE FALSE 
-        END AS is_end_of_monthly,
+        END AS is_end_of_month,
         CASE
             WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH FROM sdts) IN (1,4,7,10) THEN TRUE
             ELSE FALSE
@@ -72,7 +72,7 @@ initial_timestamps AS
         CASE
             WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
             ELSE FALSE
-        END AS is_end_of_yearly,
+        END AS is_end_of_year,
         NULL AS comment
     FROM 
         {{ last_cte }}

--- a/macros/tables/exasol/control_snap_v0.sql
+++ b/macros/tables/exasol/control_snap_v0.sql
@@ -58,9 +58,21 @@ initial_timestamps AS
             ELSE FALSE
         END AS is_monthly,
         CASE
+            WHEN sdts = date_add('day', -1, date_add('month', 1, date_trunc('month', sdts))) THEN TRUE
+            ELSE FALSE 
+        END AS is_end_of_monthly,
+        CASE
+            WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH FROM sdts) IN (1,4,7,10) THEN TRUE
+            ELSE FALSE
+        END AS is_quarterly,
+        CASE
             WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH FROM sdts) = 1 THEN TRUE
             ELSE FALSE
         END AS is_yearly,
+        CASE
+            WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
+            ELSE FALSE
+        END AS is_end_of_yearly,
         NULL AS comment
     FROM 
         {{ last_cte }}

--- a/macros/tables/exasol/control_snap_v1.sql
+++ b/macros/tables/exasol/control_snap_v1.sql
@@ -47,7 +47,7 @@ virtual_logic AS (
         {%- else %}
         CASE 
             WHEN
-            {% if 'daily' in log_logic.keys() %}
+            {% if 'daily' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
                 {%- if log_logic['daily']['forever'] == 'TRUE' -%}
                     {%- set ns.forever_status = 'TRUE' -%}
@@ -90,6 +90,32 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif -%}
 
+            {%- if 'end_of_monthly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+                {%- set cnt = cnt + 1 -%}
+                {%- if log_logic['end_of_monthly']['forever'] is true -%}
+                    {%- set ns.forever_status = 'TRUE' %}
+              (c.is_end_of_monthly = TRUE)
+                {%- else %}
+                    {%- set end_of_monthly_duration = log_logic['end_of_monthly']['duration'] -%}
+                    {%- set end_of_monthly_unit = log_logic['end_of_monthly']['unit'] %}            
+              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN  ADD_{{ end_of_monthly_unit }}S(CURRENT_DATE, -{{ end_of_monthly_duration }}) AND CURRENT_DATE)
+                AND (c.is_end_of_monthly = TRUE))
+                {%- endif -%}
+            {% endif -%}
+
+            {%- if 'quarterly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+                {%- set cnt = cnt + 1 -%}
+                {%- if log_logic['quarterly']['forever'] is true -%}
+                    {%- set ns.forever_status = 'TRUE' %}
+              (c.is_quarterly = TRUE)
+                {%- else %}
+                    {%- set quarterly_duration = log_logic['quarterly']['duration'] -%}
+                    {%- set quarterly_unit = log_logic['quarterly']['unit'] %}            
+              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN ADD_{{ quarterly_unit }}S(CURRENT_DATE, -{{ quarterly_duration }}) AND CURRENT_DATE()) 
+              AND (c.is_quarterly = TRUE))
+                {%- endif -%}
+            {% endif -%}
+
             {%- if 'yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
                 {%- if log_logic['yearly']['forever'] is true -%}
@@ -102,6 +128,19 @@ virtual_logic AS (
                     ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN ADD_{{ yearly_unit }}S(CURRENT_DATE, - {{ yearly_duration }}) AND CURRENT_DATE) 
                     AND 
                     (c.is_yearly = TRUE))
+                {%- endif -%}
+            {% endif %}
+
+            {%- if 'end_of_yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+                {%- set cnt = cnt + 1 -%}
+                {%- if log_logic['end_of_yearly']['forever'] is true -%}
+                    {%- set ns.forever_status = 'TRUE' %}
+              (c.is_end_of_yearly = TRUE)
+                {%- else %}
+                    {%- set end_of_yearly_duration = log_logic['end_of_yearly']['duration'] -%}
+                    {%- set end_of_yearly_unit = log_logic['end_of_yearly']['unit'] %}                    
+              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN ADD_{{ end_of_yearly_unit }}S(CURRENT_DATE, - {{ end_of_yearly_duration }}) AND CURRENT_DATE()) 
+              AND (c.is_end_of_yearly = TRUE))
                 {%- endif -%}
             {% endif %}
             THEN TRUE
@@ -119,7 +158,10 @@ virtual_logic AS (
         c.is_daily,
         c.is_weekly,
         c.is_monthly,
+        c.is_end_of_monthly,
+        c.is_quarterly,
         c.is_yearly,
+        c.is_end_of_yearly,
         CASE
             WHEN EXTRACT(YEAR FROM c.{{ sdts_alias }}) = EXTRACT(YEAR FROM CURRENT_DATE) THEN TRUE
             ELSE FALSE
@@ -158,7 +200,10 @@ active_logic_combined AS (
         is_daily,
         is_weekly,
         is_monthly,
+        is_end_of_monthly,
+        is_quarterly,
         is_yearly,
+        is_end_of_yearly,
         is_current_year,
         is_last_year,
         is_rolling_year,

--- a/macros/tables/exasol/control_snap_v1.sql
+++ b/macros/tables/exasol/control_snap_v1.sql
@@ -90,16 +90,16 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif -%}
 
-            {%- if 'end_of_monthly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+            {%- if 'end_of_month' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
-                {%- if log_logic['end_of_monthly']['forever'] is true -%}
+                {%- if log_logic['end_of_month']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' %}
-              (c.is_end_of_monthly = TRUE)
+              (c.is_end_of_month = TRUE)
                 {%- else %}
-                    {%- set end_of_monthly_duration = log_logic['end_of_monthly']['duration'] -%}
-                    {%- set end_of_monthly_unit = log_logic['end_of_monthly']['unit'] %}            
-              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN  ADD_{{ end_of_monthly_unit }}S(CURRENT_DATE, -{{ end_of_monthly_duration }}) AND CURRENT_DATE)
-                AND (c.is_end_of_monthly = TRUE))
+                    {%- set end_of_month_duration = log_logic['end_of_month']['duration'] -%}
+                    {%- set end_of_month_unit = log_logic['end_of_month']['unit'] %}            
+              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN  ADD_{{ end_of_month_unit }}S(CURRENT_DATE, -{{ end_of_month_duration }}) AND CURRENT_DATE)
+                AND (c.is_end_of_month = TRUE))
                 {%- endif -%}
             {% endif -%}
 
@@ -131,16 +131,16 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif %}
 
-            {%- if 'end_of_yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+            {%- if 'end_of_year' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
-                {%- if log_logic['end_of_yearly']['forever'] is true -%}
+                {%- if log_logic['end_of_year']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' %}
-              (c.is_end_of_yearly = TRUE)
+              (c.is_end_of_year = TRUE)
                 {%- else %}
-                    {%- set end_of_yearly_duration = log_logic['end_of_yearly']['duration'] -%}
-                    {%- set end_of_yearly_unit = log_logic['end_of_yearly']['unit'] %}                    
-              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN ADD_{{ end_of_yearly_unit }}S(CURRENT_DATE, - {{ end_of_yearly_duration }}) AND CURRENT_DATE()) 
-              AND (c.is_end_of_yearly = TRUE))
+                    {%- set end_of_year_duration = log_logic['end_of_year']['duration'] -%}
+                    {%- set end_of_year_unit = log_logic['end_of_year']['unit'] %}                    
+              ((DATE_TRUNC('DAY', TO_DATE(c.{{ sdts_alias }})) BETWEEN ADD_{{ end_of_year_unit }}S(CURRENT_DATE, - {{ end_of_year_duration }}) AND CURRENT_DATE()) 
+              AND (c.is_end_of_year = TRUE))
                 {%- endif -%}
             {% endif %}
             THEN TRUE
@@ -158,10 +158,10 @@ virtual_logic AS (
         c.is_daily,
         c.is_weekly,
         c.is_monthly,
-        c.is_end_of_monthly,
+        c.is_end_of_month,
         c.is_quarterly,
         c.is_yearly,
-        c.is_end_of_yearly,
+        c.is_end_of_year,
         CASE
             WHEN EXTRACT(YEAR FROM c.{{ sdts_alias }}) = EXTRACT(YEAR FROM CURRENT_DATE) THEN TRUE
             ELSE FALSE
@@ -200,10 +200,10 @@ active_logic_combined AS (
         is_daily,
         is_weekly,
         is_monthly,
-        is_end_of_monthly,
+        is_end_of_month,
         is_quarterly,
         is_yearly,
-        is_end_of_yearly,
+        is_end_of_year,
         is_current_year,
         is_last_year,
         is_rolling_year,

--- a/macros/tables/snowflake/control_snap_v0.sql
+++ b/macros/tables/snowflake/control_snap_v0.sql
@@ -46,10 +46,22 @@ enriched_timestamps AS (
             WHEN EXTRACT(DAY FROM sdts) = 1 THEN TRUE
             ELSE FALSE
         END AS is_monthly,
+        CASE 
+            WHEN LAST_DAY(sdts, 'month') = TO_DATE(sdts) THEN TRUE
+            ELSE FALSE
+        END as is_end_of_monthly,
+        CASE
+            WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH from sdts) IN (1,4,7,10) THEN TRUE
+            ELSE FALSE
+        END AS is_quarterly,
         CASE
             WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH FROM sdts) = 1 THEN TRUE
             ELSE FALSE
         END AS is_yearly,
+        CASE
+            WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
+            ELSE FALSE
+        END AS is_end_of_yearly,
         NULL AS comment
     FROM initial_timestamps
 

--- a/macros/tables/snowflake/control_snap_v0.sql
+++ b/macros/tables/snowflake/control_snap_v0.sql
@@ -49,7 +49,7 @@ enriched_timestamps AS (
         CASE 
             WHEN LAST_DAY(sdts, 'month') = TO_DATE(sdts) THEN TRUE
             ELSE FALSE
-        END as is_end_of_monthly,
+        END as is_end_of_month,
         CASE
             WHEN EXTRACT(DAY FROM sdts) = 1 AND EXTRACT(MONTH from sdts) IN (1,4,7,10) THEN TRUE
             ELSE FALSE
@@ -61,7 +61,7 @@ enriched_timestamps AS (
         CASE
             WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
             ELSE FALSE
-        END AS is_end_of_yearly,
+        END AS is_end_of_year,
         NULL AS comment
     FROM initial_timestamps
 

--- a/macros/tables/snowflake/control_snap_v1.sql
+++ b/macros/tables/snowflake/control_snap_v1.sql
@@ -83,15 +83,15 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif -%}
 
-            {%- if 'end_of_monthly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+            {%- if 'end_of_month' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
-                {%- if log_logic['end_of_monthly']['forever'] is true -%}
+                {%- if log_logic['end_of_month']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' %}
-              (c.is_end_of_monthly = TRUE)
+              (c.is_end_of_month = TRUE)
                 {%- else %}
-                    {%- set end_of_monthly_duration = log_logic['end_of_monthly']['duration'] -%}
-                    {%- set end_of_monthly_unit = log_logic['end_of_monthly']['unit'] %}            
-              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ end_of_monthly_duration }} {{ end_of_monthly_unit }}' AND CURRENT_DATE()) AND (c.is_end_of_monthly = TRUE))
+                    {%- set end_of_month_duration = log_logic['end_of_month']['duration'] -%}
+                    {%- set end_of_month_unit = log_logic['end_of_month']['unit'] %}            
+              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ end_of_month_duration }} {{ end_of_month_unit }}' AND CURRENT_DATE()) AND (c.is_end_of_month = TRUE))
                 {%- endif -%}
             {% endif -%}
 
@@ -119,15 +119,15 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif %}
 
-            {%- if 'end_of_yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+            {%- if 'end_of_year' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
-                {%- if log_logic['end_of_yearly']['forever'] is true -%}
+                {%- if log_logic['end_of_year']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' %}
-              (c.is_end_of_yearly = TRUE)
+              (c.is_end_of_year = TRUE)
                 {%- else %}
-                    {%- set end_of_yearly_duration = log_logic['end_of_yearly']['duration'] -%}
-                    {%- set end_of_yearly_unit = log_logic['end_of_yearly']['unit'] %}                    
-              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ end_of_yearly_duration }} {{ end_of_yearly_unit }}' AND CURRENT_DATE()) AND (c.is_end_of_yearly = TRUE))
+                    {%- set end_of_year_duration = log_logic['end_of_year']['duration'] -%}
+                    {%- set end_of_year_unit = log_logic['end_of_year']['unit'] %}                    
+              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ end_of_year_duration }} {{ end_of_year_unit }}' AND CURRENT_DATE()) AND (c.is_end_of_year = TRUE))
                 {%- endif -%}
             {% endif %}
             THEN TRUE
@@ -145,10 +145,10 @@ virtual_logic AS (
         c.is_daily,
         c.is_weekly,
         c.is_monthly,
-        c.is_end_of_monthly,
+        c.is_end_of_month,
         c.is_quarterly,
         c.is_yearly,
-        c.is_end_of_yearly,
+        c.is_end_of_year,
         CASE
             WHEN EXTRACT(YEAR FROM c.{{ sdts_alias }}) = EXTRACT(YEAR FROM CURRENT_DATE()) THEN TRUE
             ELSE FALSE
@@ -186,10 +186,10 @@ active_logic_combined AS (
         is_daily,
         is_weekly,
         is_monthly,
-        is_end_of_monthly,
+        is_end_of_month,
         is_quarterly,
         is_yearly,
-        is_end_of_yearly,
+        is_end_of_year,
         is_current_year,
         is_last_year,
         is_rolling_year,

--- a/macros/tables/snowflake/control_snap_v1.sql
+++ b/macros/tables/snowflake/control_snap_v1.sql
@@ -47,7 +47,7 @@ virtual_logic AS (
         {%- else %}
         CASE 
             WHEN
-            {% if 'daily' in log_logic.keys() %}
+            {% if 'daily' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
                 {%- if log_logic['daily']['forever'] is true -%}
                     {%- set ns.forever_status = 'TRUE' -%}
@@ -83,6 +83,30 @@ virtual_logic AS (
                 {%- endif -%}
             {% endif -%}
 
+            {%- if 'end_of_monthly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+                {%- set cnt = cnt + 1 -%}
+                {%- if log_logic['end_of_monthly']['forever'] is true -%}
+                    {%- set ns.forever_status = 'TRUE' %}
+              (c.is_end_of_monthly = TRUE)
+                {%- else %}
+                    {%- set end_of_monthly_duration = log_logic['end_of_monthly']['duration'] -%}
+                    {%- set end_of_monthly_unit = log_logic['end_of_monthly']['unit'] %}            
+              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ end_of_monthly_duration }} {{ end_of_monthly_unit }}' AND CURRENT_DATE()) AND (c.is_end_of_monthly = TRUE))
+                {%- endif -%}
+            {% endif -%}
+
+            {%- if 'quarterly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+                {%- set cnt = cnt + 1 -%}
+                {%- if log_logic['quarterly']['forever'] is true -%}
+                    {%- set ns.forever_status = 'TRUE' %}
+              (c.is_quarterly = TRUE)
+                {%- else %}
+                    {%- set quarterly_duration = log_logic['quarterly']['duration'] -%}
+                    {%- set quarterly_unit = log_logic['quarterly']['unit'] %}            
+              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ quarterly_duration }} {{ quarterly_unit }}' AND CURRENT_DATE()) AND (c.is_quarterly = TRUE))
+                {%- endif -%}
+            {% endif -%}
+
             {%- if 'yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
                 {%- set cnt = cnt + 1 -%}
                 {%- if log_logic['yearly']['forever'] is true -%}
@@ -92,6 +116,18 @@ virtual_logic AS (
                     {%- set yearly_duration = log_logic['yearly']['duration'] -%}
                     {%- set yearly_unit = log_logic['yearly']['unit'] %}                    
               ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ yearly_duration }} {{ yearly_unit }}' AND CURRENT_DATE()) AND (c.is_yearly = TRUE))
+                {%- endif -%}
+            {% endif %}
+
+            {%- if 'end_of_yearly' in log_logic.keys() %} {%- if cnt != 0 %} OR {% endif -%}
+                {%- set cnt = cnt + 1 -%}
+                {%- if log_logic['end_of_yearly']['forever'] is true -%}
+                    {%- set ns.forever_status = 'TRUE' %}
+              (c.is_end_of_yearly = TRUE)
+                {%- else %}
+                    {%- set end_of_yearly_duration = log_logic['end_of_yearly']['duration'] -%}
+                    {%- set end_of_yearly_unit = log_logic['end_of_yearly']['unit'] %}                    
+              ((DATE_TRUNC('DAY', c.{{ sdts_alias }}::DATE) BETWEEN CURRENT_DATE() - INTERVAL '{{ end_of_yearly_duration }} {{ end_of_yearly_unit }}' AND CURRENT_DATE()) AND (c.is_end_of_yearly = TRUE))
                 {%- endif -%}
             {% endif %}
             THEN TRUE
@@ -109,7 +145,10 @@ virtual_logic AS (
         c.is_daily,
         c.is_weekly,
         c.is_monthly,
+        c.is_end_of_monthly,
+        c.is_quarterly,
         c.is_yearly,
+        c.is_end_of_yearly,
         CASE
             WHEN EXTRACT(YEAR FROM c.{{ sdts_alias }}) = EXTRACT(YEAR FROM CURRENT_DATE()) THEN TRUE
             ELSE FALSE
@@ -147,7 +186,10 @@ active_logic_combined AS (
         is_daily,
         is_weekly,
         is_monthly,
+        is_end_of_monthly,
+        is_quarterly,
         is_yearly,
+        is_end_of_yearly,
         is_current_year,
         is_last_year,
         is_rolling_year,


### PR DESCRIPTION
Added following columns to control snapshot v0 : is_end_of_month, is_quarterly and is_end_of_year
Extended logic in control snapshot v1 to allow for thes set of parameters 'end_of_month', 'quarterly' and 'end_of_year' in the definition of a log_logic dictionary.