### PR TITLE
Removed "r" identifer in front of regex expression

### DIFF
--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -20,7 +20,7 @@ CONCAT('"', REPLACE(REPLACE(REPLACE(TRIM(CAST([EXPRESSION] AS VARCHAR(20000) UTF
 
 {%- macro snowflake__attribute_standardise() -%}
 
-CONCAT('\"', REPLACE(REPLACE(REPLACE(TRIM(CAST([EXPRESSION] AS STRING)), '\\', '\\\\'), r'\[QUOTE]', r'\\"'), '[NULL_PLACEHOLDER_STRING]', '--'), '\"')
+CONCAT('\"', REPLACE(REPLACE(REPLACE(TRIM(CAST([EXPRESSION] AS STRING)), '\\', '\\\\'), '\[QUOTE]', '\\"'), '[NULL_PLACEHOLDER_STRING]', '--'), '\"')
 
 {%- endmacro -%}
 


### PR DESCRIPTION
The changed escaping of quote characters in the hash standardization macro does not work and breaks the hash function (in Snowflake).