### PR TITLE
Fixed: same hashdiff being inserted into satellite without in between deltas

### DIFF
--- a/macros/tables/bigquery/sat_v0.sql
+++ b/macros/tables/bigquery/sat_v0.sql
@@ -52,10 +52,23 @@ latest_entries_in_sat AS (
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
 ),
 {%- endif %}
-
+{# 
+    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey. 
+#}
+deduplicate_qualify as (
+    SELECT     
+        {{ parent_hashkey }},
+        {{ ns.hdiff_alias }},
+        {{ datavault4dbt.print_list(source_cols) }}
+    FROM source_data
+    QUALIFY
+        CASE
+            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
+            ELSE TRUE
+        END
+),
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
-    Additionally adding a row number based on that order, if incremental.
+    Adding a row number based on the order of appearance in the stage (load date), if incremental.
 #}
 deduplicated_numbered_source AS (
 
@@ -66,14 +79,8 @@ deduplicated_numbered_source AS (
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
-    FROM source_data
-    QUALIFY
-        CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
-            ELSE TRUE
-        END
+    FROM deduplicate_qualify
 ),
-
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
     the existing records in the satellite.

--- a/macros/tables/exasol/sat_v0.sql
+++ b/macros/tables/exasol/sat_v0.sql
@@ -52,20 +52,14 @@ latest_entries_in_sat AS (
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
 ),
 {%- endif %}
-
-{#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
-    Additionally adding a row number based on that order, if incremental.
+{# 
+    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey. 
 #}
-deduplicated_numbered_source AS (
-
-    SELECT
-    {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
-    {{ datavault4dbt.print_list(source_cols) }}
-    {% if is_incremental() -%}
-     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
-    {%- endif %}
+deduplicate_qualify as (
+    SELECT     
+        {{ parent_hashkey }},
+        {{ ns.hdiff_alias }},
+        {{ datavault4dbt.print_list(source_cols) }}
     FROM source_data
     QUALIFY
         CASE
@@ -73,7 +67,20 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
+{#
+    Adding a row number based on the order of appearance in the stage (load date), if incremental.
+#}
+deduplicated_numbered_source AS (
 
+    SELECT
+        {{ parent_hashkey }},
+        {{ ns.hdiff_alias }},
+        {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
+    {%- endif %}
+    FROM deduplicate_qualify
+),
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
     the existing records in the satellite.

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -52,20 +52,14 @@ latest_entries_in_sat AS (
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
 ),
 {%- endif %}
-
-{#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
-    Additionally adding a row number based on that order, if incremental.
+{# 
+    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey. 
 #}
-deduplicated_numbered_source AS (
-
-    SELECT
-    {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
-    {{ datavault4dbt.print_list(source_cols) }}
-    {% if is_incremental() -%}
-    , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
-    {%- endif %}
+deduplicate_qualify as (
+    SELECT     
+        {{ parent_hashkey }},
+        {{ ns.hdiff_alias }},
+        {{ datavault4dbt.print_list(source_cols) }}
     FROM source_data
     QUALIFY
         CASE
@@ -73,7 +67,20 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
+{#
+    Adding a row number based on the order of appearance in the stage (load date), if incremental.
+#}
+deduplicated_numbered_source AS (
 
+    SELECT
+        {{ parent_hashkey }},
+        {{ ns.hdiff_alias }},
+        {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
+    {%- endif %}
+    FROM deduplicate_qualify
+),
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
     the existing records in the satellite.
@@ -91,7 +98,8 @@ records_to_insert AS (
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
             AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+            AND deduplicated_numbered_source.rn = 1
+        )
     {%- endif %}
 
     )


### PR DESCRIPTION
Split the logic in CTE `deduplicated_numbered_source` in the macro `sat_v0` into two different CTEs:

- First CTE deduplicate_qualify will apply the QUALIFY logic to the records present in the source_data deduplicating the source by comparing each hashdiff to the hashdiff of the previous record (in the stage), for each hashkey. 
- Second CTE has the same name as original CTE `deduplicated_numbered_source` and adds a ROW_NUMBER() based on hashkey when it is incremental