### PR TITLE
Passed "snapshot_trigger_column" to macro

### DIFF
--- a/macros/tables/ref_table.sql
+++ b/macros/tables/ref_table.sql
@@ -98,6 +98,7 @@ Include / Exclude per Satellite:
                                                             src_rsrc=src_rsrc,
                                                             ref_satellites=ref_satellites,
                                                             historized=historized,
-                                                            snapshot_relation=snapshot_relation)) }}
+                                                            snapshot_relation=snapshot_relation,
+                                                            snapshot_trigger_column=snapshot_trigger_column)) }}
 
 {%- endmacro -%}


### PR DESCRIPTION
The attribute "snapshot_trigger_column" was not passed to the dispatch call. Therefore custom set variables would not affect the code right now. This is fixed!

Thanks to @DPolat-Scalefree for finding the problem!