### PR TITLE
[BUGFIX][BigQuery] Fix Control Snapshot v0

### DIFF
--- a/macros/tables/bigquery/control_snap_v0.sql
+++ b/macros/tables/bigquery/control_snap_v0.sql
@@ -55,7 +55,7 @@ enriched_timestamps AS (
             ELSE FALSE
         END as is_monthly,
         CASE 
-            WHEN LAST_DAY(sdts, 'month') = DATE(sdts) THEN TRUE
+            WHEN LAST_DAY(DATE(sdts), MONTH) = DATE(sdts) THEN TRUE
             ELSE FALSE
         END as is_end_of_month,
         CASE
@@ -67,7 +67,7 @@ enriched_timestamps AS (
             ELSE FALSE
         END as is_yearly,
         CASE
-            WHEN EXTRACT(DAY FROM sdts)=31 AND EXTRACT(MONTH FROM sdts) = 12 THEN TRUE
+            WHEN LAST_DAY(DATE(sdts), YEAR) = DATE(sdts) THEN TRUE
             ELSE FALSE
         END AS is_end_of_year,
         NULL as comment


### PR DESCRIPTION
Since last update (datavault4dbt v.1.1.4) it was reported that this statement threw and error in BigQuery adapter:
```
CASE 
    WHEN LAST_DAY(sdts, 'month') = DATE(sdts) THEN TRUE
    ELSE FALSE
END as is_end_of_month,
```
The issue was resolved by replacing it with:
```
CASE 
    WHEN LAST_DAY(DATE(sdts), MONTH) = DATE(sdts) THEN TRUE
    ELSE FALSE
END as is_end_of_month,
```