### PR TITLE
add big query macro in ghost_record_per_datatype

### DIFF
--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -393,3 +393,43 @@
 {%- endif -%}
 
 {%- endmacro -%}
+
+
+{%- macro bigquery__ghost_record_per_datatype(column_name, datatype, ghost_record_type, col_size, alias) -%}
+
+{%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
+{%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
+{%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+
+{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
+{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
+{%- set date_format = var('datavault4dbt.date_format', '%Y-%m-%d') -%}
+
+{%- set datatype = datatype | string | upper | trim -%}
+
+{%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
+{%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
+{%- if ghost_record_type == 'unknown' -%}
+        {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , beginning_of_all_times) }} as {{ alias }}
+        {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}','{{ beginning_of_all_times_date }}') as {{ alias }}
+        {%- elif datatype == 'STRING' %} '{{unknown_value__STRING}}' as {{ alias }}
+        {%- elif datatype == 'INT64' %} CAST('0' as INT64) as {{ alias }}
+        {%- elif datatype == 'FLOAT64' %} CAST('0' as FLOAT64) as {{ alias }}
+        {%- elif datatype == 'BOOLEAN' %} CAST('FALSE' as BOOLEAN) as {{ alias }}
+        {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
+        {% endif %}
+{%- elif ghost_record_type == 'error' -%}
+        {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }} as {{ alias }}
+        {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}', '{{ end_of_all_times_date }}') as {{ alias }}
+        {%- elif datatype == 'STRING' %} '{{error_value__STRING}}' as {{ alias }}
+        {%- elif datatype == 'INT64' %} CAST('-1' as INT64) as {{ alias }}
+        {%- elif datatype == 'FLOAT64' %} CAST('-1' as FLOAT64) as {{ alias }}
+        {%- elif datatype == 'BOOLEAN' %} CAST('FALSE' as BOOLEAN) as {{ alias }}
+        {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
+        {% endif %}
+{%- else -%}
+    {%- if execute -%}
+        {{ exceptions.raise_compiler_error("Invalid Ghost Record Type. Accepted are 'unknown' and 'error'.") }}
+    {%- endif %}
+{%- endif -%}
+{%- endmacro -%}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -20,7 +20,7 @@
 
 {%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
 {%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-{%- set date_format = var('datavault4dbt.date_format', 'YYYY-mm-dd') -%}
+{%- set date_format = var('datavault4dbt.date_format', '%Y-%m-%d') -%}
 
 {%- set datatype = datatype | string | upper | trim -%}
 
@@ -28,7 +28,7 @@
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
 {%- if ghost_record_type == 'unknown' -%}
         {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , beginning_of_all_times) }} as {{ alias }}
-        {%- elif datatype == 'DATE'-%} TO_DATE('{{ beginning_of_all_times_date }}', '{{ date_format }}' ) as "{{ alias }}"
+        {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}','{{ beginning_of_all_times_date }}') as {{ alias }}
         {%- elif datatype == 'STRING' %} '{{unknown_value__STRING}}' as {{ alias }}
         {%- elif datatype == 'INT64' %} CAST('0' as INT64) as {{ alias }}
         {%- elif datatype == 'FLOAT64' %} CAST('0' as FLOAT64) as {{ alias }}
@@ -37,7 +37,7 @@
         {% endif %}
 {%- elif ghost_record_type == 'error' -%}
         {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }} as {{ alias }}
-        {%- elif datatype == 'DATE'-%} TO_DATE('{{ end_of_all_times_date }}', '{{ date_format }}' ) as "{{ alias }}"
+        {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}', '{{ end_of_all_times_date }}') as {{ alias }}
         {%- elif datatype == 'STRING' %} '{{error_value__STRING}}' as {{ alias }}
         {%- elif datatype == 'INT64' %} CAST('-1' as INT64) as {{ alias }}
         {%- elif datatype == 'FLOAT64' %} CAST('-1' as FLOAT64) as {{ alias }}
@@ -392,44 +392,4 @@
     {%- endif %}
 {%- endif -%}
 
-{%- endmacro -%}
-
-
-{%- macro bigquery__ghost_record_per_datatype(column_name, datatype, ghost_record_type, col_size, alias) -%}
-
-{%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
-{%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
-{%- set timestamp_format = datavault4dbt.timestamp_format() -%}
-
-{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
-{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-{%- set date_format = var('datavault4dbt.date_format', '%Y-%m-%d') -%}
-
-{%- set datatype = datatype | string | upper | trim -%}
-
-{%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
-{%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
-{%- if ghost_record_type == 'unknown' -%}
-        {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , beginning_of_all_times) }} as {{ alias }}
-        {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}','{{ beginning_of_all_times_date }}') as {{ alias }}
-        {%- elif datatype == 'STRING' %} '{{unknown_value__STRING}}' as {{ alias }}
-        {%- elif datatype == 'INT64' %} CAST('0' as INT64) as {{ alias }}
-        {%- elif datatype == 'FLOAT64' %} CAST('0' as FLOAT64) as {{ alias }}
-        {%- elif datatype == 'BOOLEAN' %} CAST('FALSE' as BOOLEAN) as {{ alias }}
-        {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
-        {% endif %}
-{%- elif ghost_record_type == 'error' -%}
-        {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }} as {{ alias }}
-        {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}', '{{ end_of_all_times_date }}') as {{ alias }}
-        {%- elif datatype == 'STRING' %} '{{error_value__STRING}}' as {{ alias }}
-        {%- elif datatype == 'INT64' %} CAST('-1' as INT64) as {{ alias }}
-        {%- elif datatype == 'FLOAT64' %} CAST('-1' as FLOAT64) as {{ alias }}
-        {%- elif datatype == 'BOOLEAN' %} CAST('FALSE' as BOOLEAN) as {{ alias }}
-        {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
-        {% endif %}
-{%- else -%}
-    {%- if execute -%}
-        {{ exceptions.raise_compiler_error("Invalid Ghost Record Type. Accepted are 'unknown' and 'error'.") }}
-    {%- endif %}
-{%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
Add big query macro in macros/supporting/ghost_record_per_datatype.sql

Steps:
1. Copied the default__ macro to the bottom
2. Unquoted the `{{alias}}`
3. Changed `TO_DATE` to `PARSE_DATE` since `TO_DATE` is not supported in big query
4. Changed `date_format ` default value in big query macro to `'%Y-%m-%d'` because `'YYYY-MM-DD'` produced errors
5. Changed name to `bigquery__ghost_record_per_datatype`