### PR TITLE
Change hash_datatype from BINARY(16) to VARCHAR(32) for Redshift Compatibility

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,7 +35,7 @@ vars:
   datavault4dbt.deleted_flag_alias: 'deleted_flag'
   #Hash Configuration
   datavault4dbt.hash: 'MD5'
-  datavault4dbt.hash_datatype: 'BINARY(16)' #changed from string
+  datavault4dbt.hash_datatype: 'VARCHAR(32)' #changed from string
   datavault4dbt.hashkey_input_case_sensitive: FALSE
   datavault4dbt.hashdiff_input_case_sensitive: TRUE
   


### PR DESCRIPTION
### Description
This pull request addresses an issue encountered with the datavault4dbt project on Redshift databases. Due to Redshift's lack of support for the BINARY(16) data type, using this data type causes syntax errors in compiled queries. To resolve this, I propose changing the data type of datavault4dbt.hash_datatype from BINARY(16) to VARCHAR(32).

### Motivation and Context
This change is necessary to ensure that the datavault4dbt project is compatible with Redshift, enabling users to run datavault models without encountering syntax errors related to unsupported data types. More details can be found in the related issue: [Issue #171](https://github.com/ScalefreeCOM/datavault4dbt/issues/171).

### Changes
The main change is in the dbt_project.yml configuration:

```
vars:
  ..
  datavault4dbt.hash_datatype: 'VARCHAR(32)' # changed from BINARY(16)
  ..
```
### Testing
-

### Checklist
-