### PR TITLE
Change global var hash datatype to string

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,7 +35,7 @@ vars:
   datavault4dbt.deleted_flag_alias: 'deleted_flag'
   #Hash Configuration
   datavault4dbt.hash: 'MD5'
-  datavault4dbt.hash_datatype: 'BINARY(16)' #changed from string
+  datavault4dbt.hash_datatype: 'STRING'
   datavault4dbt.hashkey_input_case_sensitive: FALSE
   datavault4dbt.hashdiff_input_case_sensitive: TRUE
   

--- a/macros/staging/synapse/stage.sql
+++ b/macros/staging/synapse/stage.sql
@@ -157,7 +157,7 @@
 {#- Setting unknown and error keys with default values for the selected hash algorithm -#}
 {%- set hash = datavault4dbt.hash_method() -%}
 {{ log('hash_function: ' ~ hash, false)}}
-{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
+{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'BINARY(16)') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}
 {%- set unknown_key = hash_default_values['unknown_key'] -%}

--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -160,7 +160,7 @@
 {%- set hashdiff_input_case_sensitive = var('datavault4dbt.hashdiff_input_case_sensitive', TRUE) -%}
 
 {#- Select hashing algorithm -#}
-{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
+{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'BINARY(16)') -%}
 {{ log('hash type in hash macro: ' ~ hash_dtype, false) }}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}

--- a/macros/tables/synapse/pit.sql
+++ b/macros/tables/synapse/pit.sql
@@ -1,7 +1,7 @@
 {%- macro synapse__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
 
 {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
-{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
+{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'BINARY(16)') -%}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}
 {%- set unknown_key = hash_default_values['unknown_key'] -%}


### PR DESCRIPTION
This PR changes the global variable, as defined in the dbt_project.yml, for the `hash_datatype` back to String.
For the case, that no global variable is defined in the dbt_project.yml the default-values for synapse were changed to Binary(16) (staging/synapse/stage.sql, supporting/hash.sql, tables/synapse/pit.sql).
To inform Synapse users of the correct value for the global variable an addition to the [synapse specific notes](https://github.com/ScalefreeCOM/datavault4dbt/wiki/Synapse-Specific-Notes) should be made.