### PR TITLE
change copy_rsrc_ldts_input_columns to false

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,7 +40,7 @@ vars:
   datavault4dbt.hashdiff_input_case_sensitive: TRUE
   
   #Stage Configuration
-  datavault4dbt.copy_rsrc_ldts_input_columns: true  
+  datavault4dbt.copy_rsrc_ldts_input_columns: false
 
   #General Configuration
   datavault4dbt.include_business_objects_before_appearance: false


### PR DESCRIPTION
This PR changes the value of `copy_rsrc_ldts_input_columns` back to false.
The hardcoded default in the staging macros is (unchanged) at false and the global variable default should reflect this behavior.