### PR TITLE
Add macros for global date variables and use them in ghost_records_per_datatype

### DIFF
--- a/macros/supporting/beginning_of_all_times_date.sql
+++ b/macros/supporting/beginning_of_all_times_date.sql
@@ -92,12 +92,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (synapse) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set beginning_of_all_times_date = "1901-01-01T00:00:01" -%}
+        {%- set beginning_of_all_times_date = "1901-01-01" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set beginning_of_all_times_date = global_var -%}
 {%- else -%}        
-    {%- set beginning_of_all_times_date = "1901-01-01T00:00:01" -%}
+    {%- set beginning_of_all_times_date = "1901-01-01" -%}
 {%- endif -%}
 
 {{ return(beginning_of_all_times_date) }}

--- a/macros/supporting/beginning_of_all_times_date.sql
+++ b/macros/supporting/beginning_of_all_times_date.sql
@@ -1,0 +1,155 @@
+{%- macro beginning_of_all_times_date() %}
+
+    {{ return( adapter.dispatch('beginning_of_all_times_date', 'datavault4dbt')() ) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__beginning_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.beginning_of_all_times_date', none) -%}
+{%- set beginning_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'bigquery' in global_var.keys()|map('lower') -%}
+        {% set beginning_of_all_times_date = global_var['bigquery'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set beginning_of_all_times_date = "0001-01-01" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set beginning_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set beginning_of_all_times_date = "0001-01-01" -%}
+{%- endif -%}
+
+{{ return(beginning_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro snowflake__beginning_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.beginning_of_all_times_date', none) -%}
+{%- set beginning_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'snowflake' in global_var.keys()|map('lower') -%}
+        {% set beginning_of_all_times_date = global_var['snowflake'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set beginning_of_all_times_date = "0001-01-01" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set beginning_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set beginning_of_all_times_date = "0001-01-01" -%}
+{%- endif -%}
+
+{{ return(beginning_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro exasol__beginning_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.beginning_of_all_times_date', none) -%}
+{%- set beginning_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'exasol' in global_var.keys()|map('lower') -%}
+        {% set beginning_of_all_times_date = global_var['exasol'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (exasol) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set beginning_of_all_times_date = "0001-01-01" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set beginning_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set beginning_of_all_times_date = "0001-01-01" -%}
+{%- endif -%}
+
+{{ return(beginning_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro synapse__beginning_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.beginning_of_all_times_date', none) -%}
+{%- set beginning_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}    
+    {%- if 'synapse' in global_var.keys()|map('lower') -%}
+        {% set beginning_of_all_times_date = global_var['synapse'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (synapse) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set beginning_of_all_times_date = "1901-01-01T00:00:01" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set beginning_of_all_times_date = global_var -%}
+{%- else -%}        
+    {%- set beginning_of_all_times_date = "1901-01-01T00:00:01" -%}
+{%- endif -%}
+
+{{ return(beginning_of_all_times_date) }}
+
+{%- endmacro -%}  
+
+
+{%- macro postgres__beginning_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.beginning_of_all_times_date', none) -%}
+{%- set beginning_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'postgres' in global_var.keys()|map('lower') -%}
+        {% set beginning_of_all_times_date = global_var['postgres'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (postgres) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set beginning_of_all_times_date = "0001-01-01" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set beginning_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set beginning_of_all_times_date = "0001-01-01" -%}
+{%- endif -%}
+
+{{ return(beginning_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro redshift__beginning_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.beginning_of_all_times_date', none) -%}
+{%- set beginning_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'redshift' in global_var.keys()|map('lower') -%}
+        {% set beginning_of_all_times_date = global_var['redshift'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.beginning_of_all_times_date' to a dictionary, but have not included the adapter you use (redshift) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set beginning_of_all_times_date = "0001-01-01" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set beginning_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set beginning_of_all_times_date = "0001-01-01" -%}
+{%- endif -%}
+
+{{ return(beginning_of_all_times_date) }}
+
+{%- endmacro -%}

--- a/macros/supporting/date_format.sql
+++ b/macros/supporting/date_format.sql
@@ -1,0 +1,155 @@
+{%- macro date_format() %}
+
+    {{ return(adapter.dispatch('date_format', 'datavault4dbt')()) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__date_format() %}
+
+{%- set global_var = var('datavault4dbt.date_format', none) -%}
+{%- set date_format = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'bigquery' in global_var.keys()|map('lower') -%}
+        {% set date_format = global_var['bigquery'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.date_format' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set date_format = "%Y-%m-%d" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set date_format = global_var -%}
+{%- else -%}
+    {%- set date_format = "%Y-%m-%d" -%}
+{%- endif -%}
+
+{{ return(date_format) }}
+
+{%- endmacro -%}
+
+
+{%- macro snowflake__date_format() %}
+
+{%- set global_var = var('datavault4dbt.date_format', none) -%}
+{%- set date_format = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'snowflake' in global_var.keys()|map('lower') -%}
+        {% set date_format = global_var['snowflake'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.date_format' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set date_format = "YYYY-MM-DD" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set date_format = global_var -%}
+{%- else -%}
+    {%- set date_format = "YYYY-MM-DD" -%}
+{%- endif -%}
+
+{{ return(date_format) }}
+
+{%- endmacro -%}
+
+
+{%- macro exasol__date_format() %}
+
+{%- set global_var = var('datavault4dbt.date_format', none) -%}
+{%- set date_format = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'exasol' in global_var.keys()|map('lower') -%}
+        {% set date_format = global_var['exasol'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.date_format' to a dictionary, but have not included the adapter you use (exasol) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set date_format = "YYYY-mm-dd" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set date_format = global_var -%}
+{%- else -%}
+    {%- set date_format = "YYYY-mm-dd" -%}
+{%- endif -%}
+
+{{ return(date_format) }}
+
+{%- endmacro -%}
+
+
+{%- macro synapse__date_format() %}
+
+{%- set global_var = var('datavault4dbt.date_format', none) -%}
+{%- set date_format = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'synapse' in global_var.keys()|map('lower') -%}
+        {% set date_format = global_var['synapse'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.date_format' to a dictionary, but have not included the adapter you use (synapse) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set date_format = "yyyy-MM-dd" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set date_format = global_var -%}
+{%- else -%}  
+    {%- set date_format = "yyyy-MM-dd" -%}
+{%- endif -%}
+
+{{ return(date_format) }} 
+
+{%- endmacro -%}
+
+
+{%- macro postgres__date_format() %}
+
+{%- set global_var = var('datavault4dbt.date_format', none) -%}
+{%- set date_format = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'postgres' in global_var.keys()|map('lower') -%}
+        {% set date_format = global_var['postgres'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.date_format' to a dictionary, but have not included the adapter you use (postgres) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set date_format = "%Y-%m-%d" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set date_format = global_var -%}
+{%- else -%}
+    {%- set date_format = "%Y-%m-%d" -%}
+{%- endif -%}
+
+{{ return(date_format) }}
+
+{%- endmacro -%}
+
+{%- macro redshift__date_format() %}
+
+{%- set global_var = var('datavault4dbt.date_format', none) -%}
+{%- set date_format = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'redshift' in global_var.keys()|map('lower') -%}
+        {% set date_format = global_var['redshift'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.date_format' to a dictionary, but have not included the adapter you use (redshift) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set date_format = "YYYY-MM-DD" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set date_format = global_var -%}
+{%- else -%}
+    {%- set date_format = "YYYY-MM-DD" -%}
+{%- endif -%}
+
+{{ return(date_format) }}
+
+{%- endmacro -%}
+

--- a/macros/supporting/end_of_all_times.sql
+++ b/macros/supporting/end_of_all_times.sql
@@ -81,7 +81,7 @@
 
 
 {%- macro synapse__end_of_all_times() %}
-    
+
 {%- set global_var = var('datavault4dbt.end_of_all_times', none) -%}
 {%- set end_of_all_times = '' -%}
 
@@ -96,11 +96,11 @@
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set end_of_all_times = global_var -%}
-{%- else -%}        
+{%- else -%}
     {%- set end_of_all_times = "8888-12-31T23:59:59" -%}
 {%- endif -%}
 
-{{ return(end_of_all_times) }}    
+{{ return(end_of_all_times) }}
 {%- endmacro -%}
 
 
@@ -127,3 +127,26 @@
 {{ return(end_of_all_times) }}
 {%- endmacro -%}
 
+
+{%- macro postgres__end_of_all_times() %}
+    
+{%- set global_var = var('datavault4dbt.end_of_all_times', none) -%}
+{%- set end_of_all_times = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'postgres' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times = global_var['postgres'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times' to a dictionary, but have not included the adapter you use (postgres) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times = "8888-12-31T23:59:59" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times = global_var -%}
+{%- else -%}        
+    {%- set end_of_all_times = "8888-12-31T23:59:59" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times) }}    
+{%- endmacro -%}

--- a/macros/supporting/end_of_all_times_date.sql
+++ b/macros/supporting/end_of_all_times_date.sql
@@ -1,0 +1,152 @@
+{%- macro end_of_all_times_date() %}
+
+    {{ return(adapter.dispatch('end_of_all_times_date', 'datavault4dbt')()) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__end_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.end_of_all_times_date', none) -%}
+{%- set end_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'bigquery' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times_date = global_var['bigquery'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times_date = "8888-12-31" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set end_of_all_times_date = "8888-12-31" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro snowflake__end_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.end_of_all_times_date', none) -%}
+{%- set end_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'snowflake' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times_date = global_var['snowflake'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times_date = "8888-12-31T23:59:59" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set end_of_all_times_date = "8888-12-31T23:59:59" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro exasol__end_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.end_of_all_times_date', none) -%}
+{%- set end_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'exasol' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times_date = global_var['exasol'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (exasol) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times_date = "8888-12-31" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set end_of_all_times_date = "8888-12-31" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times_date) }}
+
+{%- endmacro -%}
+
+
+{%- macro postgres__end_of_all_times_date() %}
+    
+{%- set global_var = var('datavault4dbt.end_of_all_times_date', none) -%}
+{%- set end_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'postgres' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times_date = global_var['postgres'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (postgres) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times_date = "8888-12-31" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times_date = global_var -%}
+{%- else -%}        
+    {%- set end_of_all_times_date = "8888-12-31" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times_date) }}    
+{%- endmacro -%}
+
+
+{%- macro redshift__end_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.end_of_all_times_date', none) -%}
+{%- set end_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'redshift' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times_date = global_var['redshift'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (redshift) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times_date = "8888-12-31" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set end_of_all_times_date = "8888-12-31" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times_date) }}
+{%- endmacro -%}
+
+
+{%- macro synapse__end_of_all_times_date() %}
+
+{%- set global_var = var('datavault4dbt.end_of_all_times_date', none) -%}
+{%- set end_of_all_times_date = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'synapse' in global_var.keys()|map('lower') -%}
+        {% set end_of_all_times_date = global_var['synapse'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (synapse) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set end_of_all_times_date = "8888-12-31" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set end_of_all_times_date = global_var -%}
+{%- else -%}
+    {%- set end_of_all_times_date = "8888-12-31" -%}
+{%- endif -%}
+
+{{ return(end_of_all_times_date) }}
+{%- endmacro -%}

--- a/macros/supporting/end_of_all_times_date.sql
+++ b/macros/supporting/end_of_all_times_date.sql
@@ -42,12 +42,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.end_of_all_times_date' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set end_of_all_times_date = "8888-12-31T23:59:59" -%}
+        {%- set end_of_all_times_date = "8888-12-31" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set end_of_all_times_date = global_var -%}
 {%- else -%}
-    {%- set end_of_all_times_date = "8888-12-31T23:59:59" -%}
+    {%- set end_of_all_times_date = "8888-12-31" -%}
 {%- endif -%}
 
 {{ return(end_of_all_times_date) }}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -27,7 +27,7 @@
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
 {%- if ghost_record_type == 'unknown' -%}
-        {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , beginning_of_all_times) }} as {{ alias }}
+        {%- if datatype == 'TIMESTAMP' or datatype == 'DATETIME' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , beginning_of_all_times) }} as {{ alias }}
         {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}','{{ beginning_of_all_times_date }}') as {{ alias }}
         {%- elif datatype == 'STRING' %} '{{unknown_value__STRING}}' as {{ alias }}
         {%- elif datatype == 'INT64' %} CAST('0' as INT64) as {{ alias }}
@@ -36,7 +36,7 @@
         {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
         {% endif %}
 {%- elif ghost_record_type == 'error' -%}
-        {%- if datatype == 'TIMESTAMP' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }} as {{ alias }}
+        {%- if datatype == 'TIMESTAMP' or datatype == 'DATETIME' %} {{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }} as {{ alias }}
         {%- elif datatype == 'DATE'-%} PARSE_DATE('{{date_format}}', '{{ end_of_all_times_date }}') as {{ alias }}
         {%- elif datatype == 'STRING' %} '{{error_value__STRING}}' as {{ alias }}
         {%- elif datatype == 'INT64' %} CAST('-1' as INT64) as {{ alias }}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -156,8 +156,6 @@
 {%- set unknown_value_alt__STRING = var('datavault4dbt.unknown_value_alt__STRING', 'u')  -%}
 {%- set error_value_alt__STRING = var('datavault4dbt.error_value_alt__STRING', 'e')  -%}
 {%- set datatype = datatype | string | upper | trim -%}
-    
-{%- set alias = datavault4dbt.escape_column_names(alias) -%}
 
 {%- set alias = datavault4dbt.escape_column_names(alias) -%}
 

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -156,12 +156,12 @@
 {%- set unknown_value_alt__STRING = var('datavault4dbt.unknown_value_alt__STRING', 'u')  -%}
 {%- set error_value_alt__STRING = var('datavault4dbt.error_value_alt__STRING', 'e')  -%}
 {%- set datatype = datatype | string | upper | trim -%}
-
+    
 {%- if ghost_record_type == 'unknown' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }} AS {{ alias }}
-     {%- elif datatype == 'DATE'-%} TO_DATE('{{ beginning_of_all_times_date }}', '{{ date_format }}' ) as "{{ alias }}"
+     {%- elif datatype == 'DATE'-%} TO_DATE('{{ beginning_of_all_times_date }}', '{{ date_format }}' ) as {{ alias }}
      {%- elif datatype in ['STRING', 'VARCHAR'] %}'{{ unknown_value__STRING }}' AS {{ alias }}
-     {%- elif datatype == 'CHAR' %}CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as "{{ alias }}"
+     {%- elif datatype == 'CHAR' %}CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as {{ alias }}
      {%- elif datatype.upper().startswith('VARCHAR(') or datatype.upper().startswith('CHAR(') -%}
             {%- if col_size is not none -%}
                 {%- set unknown_dtype_length = col_size | int -%}
@@ -174,9 +174,9 @@
                 {%- set unknown_dtype_length = inside_parenthesis | int -%}
             {%- endif -%}
             {%- if unknown_dtype_length < unknown_value__STRING|length -%}
-                CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as "{{ alias }}"
+                CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as {{ alias }}
             {%- else -%}
-                CAST('{{ unknown_value__STRING }}' as {{ datatype }} ) as "{{ alias }}"
+                CAST('{{ unknown_value__STRING }}' as {{ datatype }} ) as {{ alias }}
             {%- endif -%}
      {%- elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}0 AS {{ alias }}
      {%- elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ alias }}
@@ -184,9 +184,9 @@
      {% endif %}
 {%- elif ghost_record_type == 'error' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }} AS {{ alias }}
-     {%- elif datatype == 'DATE'-%} TO_DATE('{{ end_of_all_times_date }}', '{{ date_format }}' ) as "{{ alias }}"
+     {%- elif datatype == 'DATE'-%} TO_DATE('{{ end_of_all_times_date }}', '{{ date_format }}' ) as {{ alias }}
      {%- elif datatype in ['STRING','VARCHAR'] %}'{{ error_value__STRING }}' AS {{ alias }}
-     {%- elif datatype == 'CHAR' %}CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as "{{ alias }}"
+     {%- elif datatype == 'CHAR' %}CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as {{ alias }}
      {%- elif datatype.upper().startswith('VARCHAR(')  or datatype.upper().startswith('CHAR(') -%}
             {%- if col_size is not none -%}
                 {%- set error_dtype_length = col_size | int -%}
@@ -199,9 +199,9 @@
                 {%- set error_dtype_length = inside_parenthesis | int -%}
             {%- endif -%}
             {%- if error_dtype_length < error_value__STRING|length  -%}
-                CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as "{{ alias }}"
+                CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as {{ alias }}
             {%- else -%}
-                CAST('{{ error_value__STRING }}' as {{ datatype }} ) as "{{ alias }}"
+                CAST('{{ error_value__STRING }}' as {{ datatype }} ) as {{ alias }}
             {%- endif -%}
      {% elif datatype in ['NUMBER','INT','FLOAT','DECIMAL'] %}-1 AS {{ alias }}
      {% elif datatype == 'BOOLEAN' %}CAST('FALSE' AS BOOLEAN) AS {{ alias }}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -156,7 +156,9 @@
 {%- set unknown_value_alt__STRING = var('datavault4dbt.unknown_value_alt__STRING', 'u')  -%}
 {%- set error_value_alt__STRING = var('datavault4dbt.error_value_alt__STRING', 'e')  -%}
 {%- set datatype = datatype | string | upper | trim -%}
-    
+
+{%- set alias = datavault4dbt.escape_column_names(alias) -%}
+
 {%- if ghost_record_type == 'unknown' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }} AS {{ alias }}
      {%- elif datatype == 'DATE'-%} TO_DATE('{{ beginning_of_all_times_date }}', '{{ date_format }}' ) as {{ alias }}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -18,9 +18,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
-{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-{%- set date_format = var('datavault4dbt.date_format', '%Y-%m-%d') -%}
+{%- set beginning_of_all_times_date = datavault4dbt.beginning_of_all_times_date() -%}
+{%- set end_of_all_times_date = datavault4dbt.end_of_all_times_date() -%}
+{%- set date_format = datavault4dbt.date_format() -%}
 
 {%- set datatype = datatype | string | upper | trim -%}
 
@@ -58,9 +58,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
-{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-{%- set date_format = var('datavault4dbt.date_format', 'YYYY-mm-dd') -%}
+{%- set beginning_of_all_times_date = datavault4dbt.beginning_of_all_times_date() -%}
+{%- set end_of_all_times_date = datavault4dbt.end_of_all_times_date() -%}
+{%- set date_format = datavault4dbt.date_format() -%}
 
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
@@ -147,9 +147,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
-{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-{%- set date_format = var('datavault4dbt.date_format', 'YYYY-mm-dd') -%}
+{%- set beginning_of_all_times_date = datavault4dbt.beginning_of_all_times_date() -%}
+{%- set end_of_all_times_date = datavault4dbt.end_of_all_times_date() -%}
+{%- set date_format = datavault4dbt.date_format() -%}
 
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
@@ -217,6 +217,14 @@
 
 
 {%- macro synapse__ghost_record_per_datatype(column_name, datatype, ghost_record_type, col_size, alias) -%}
+
+{%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
+{%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
+{%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+
+{%- set beginning_of_all_times_date = datavault4dbt.beginning_of_all_times_date() -%}
+{%- set end_of_all_times_date = datavault4dbt.end_of_all_times_date() -%}
+{%- set date_format = datavault4dbt.date_format() -%}
 
 
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
@@ -307,10 +315,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
-{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-
-{%- set date_format = var('datavault4dbt.date_format', 'YYYY-mm-dd') -%}
+{%- set beginning_of_all_times_date = datavault4dbt.beginning_of_all_times_date() -%}
+{%- set end_of_all_times_date = datavault4dbt.end_of_all_times_date() -%}
+{%- set date_format = datavault4dbt.date_format() -%}
 
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
@@ -348,9 +355,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set beginning_of_all_times_date = var('datavault4dbt.beginning_of_all_times_date', '0001-01-01') -%}
-{%- set end_of_all_times_date = var('datavault4dbt.end_of_all_times_date', '8888-12-31') -%}
-{%- set date_format = var('datavault4dbt.date_format', 'YYYY-mm-dd') -%}
+{%- set beginning_of_all_times_date = datavault4dbt.beginning_of_all_times_date() -%}
+{%- set end_of_all_times_date = datavault4dbt.end_of_all_times_date() -%}
+{%- set date_format = datavault4dbt.date_format() -%}
 
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -162,7 +162,7 @@
 {%- if ghost_record_type == 'unknown' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }} AS {{ alias }}
      {%- elif datatype == 'DATE'-%} TO_DATE('{{ beginning_of_all_times_date }}', '{{ date_format }}' ) as {{ alias }}
-     {%- elif datatype in ['STRING', 'VARCHAR'] %}'{{ unknown_value__STRING }}' AS {{ alias }}
+     {%- elif datatype in ['STRING', 'VARCHAR', 'TEXT'] %}'{{ unknown_value__STRING }}' AS {{ alias }}
      {%- elif datatype == 'CHAR' %}CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }} ) as {{ alias }}
      {%- elif datatype.upper().startswith('VARCHAR(') or datatype.upper().startswith('CHAR(') -%}
             {%- if col_size is not none -%}
@@ -187,7 +187,7 @@
 {%- elif ghost_record_type == 'error' -%}
      {%- if datatype in ['TIMESTAMP_NTZ','TIMESTAMP'] %}{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }} AS {{ alias }}
      {%- elif datatype == 'DATE'-%} TO_DATE('{{ end_of_all_times_date }}', '{{ date_format }}' ) as {{ alias }}
-     {%- elif datatype in ['STRING','VARCHAR'] %}'{{ error_value__STRING }}' AS {{ alias }}
+     {%- elif datatype in ['STRING', 'VARCHAR', 'TEXT'] %}'{{ error_value__STRING }}' AS {{ alias }}
      {%- elif datatype == 'CHAR' %}CAST('{{ error_value_alt__STRING }}' as {{ datatype }} ) as {{ alias }}
      {%- elif datatype.upper().startswith('VARCHAR(')  or datatype.upper().startswith('CHAR(') -%}
             {%- if col_size is not none -%}


### PR DESCRIPTION
Hi,

this PR adds the missing macros to resolve the global variables for beginning and end of all times date and the respective date format, when they are set as a dictionary in dbt_project.yml.

Currently, the complete dictionary gets returned when it is set in the dbt_project.yml, if not set the default specified in ghost_record_per_datatype is used.

I have copied the existing macros for the timestamps and modified them to return dates.

In the process I found that in the existing end_of_all_times-macro a postgres-specific macro was missing which I added.

Then I have modified the ghost_records_per_datatype-macro to use the new macros.

Kind Regards
Theo