### PR TITLE
Update current_timestamp-macro and add default ldts value to stage macro

### DIFF
--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -108,6 +108,11 @@
     {%- if include_source_columns is none or include_source_columns == "" -%}
       {%- set include_source_columns = true -%}
     {%- endif -%}
+    
+    {# If ldts is empty replace it with the current timestamp #}
+    {%- if datavault4dbt.is_nothing(ldts) == True -%}
+      {%- set ldts = datavault4dbt.current_timestamp() -%}
+    {%- endif -%}
 
     {{- adapter.dispatch('stage', 'datavault4dbt')(include_source_columns=include_source_columns,
                                         ldts=ldts,

--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -110,7 +110,7 @@
     {%- endif -%}
     
     {# If ldts is empty replace it with the current timestamp #}
-    {%- if datavault4dbt.is_nothing(ldts) == True -%}
+    {%- if datavault4dbt.is_nothing(ldts) -%}
       {%- set ldts = datavault4dbt.current_timestamp() -%}
     {%- endif -%}
 

--- a/macros/supporting/current_timestamp.sql
+++ b/macros/supporting/current_timestamp.sql
@@ -3,7 +3,7 @@
 {%- endmacro %}
 
 {% macro default__current_timestamp() %}
-    {{ dbt_utils.current_timestamp() }}
+    {{ dbt.current_timestamp() }}
 {% endmacro %}
 
 {% macro synapse__current_timestamp() %}
@@ -15,7 +15,7 @@
 {%- endmacro %}
 
 {% macro default__current_timestamp_in_utc() %}
-    {{dbt_utils.current_timestamp_in_utc()}}
+    {{dbt.current_timestamp() }}
 {% endmacro %}
 
 {% macro synapse__current_timestamp_in_utc() %}

--- a/macros/supporting/datatypes.sql
+++ b/macros/supporting/datatypes.sql
@@ -3,7 +3,7 @@
 {%- endmacro -%}
 
 {%- macro default__type_timestamp() -%}
-    {{ type_timestamp() }}
+    {{ dbt.type_timestamp() }}
 {%- endmacro -%}
 
 {%- macro synapse__type_timestamp() -%}


### PR DESCRIPTION
Update current_timestamp-macro to use the built-in current_timestamp-function.
The return values may differ between adapters ([docs](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#current_timestamp)).

Also add the functionality that if no ldts is specified in the staging-macro the current timestamp is passed as parameter to the macro call

Additionally remove recursive call in type_timestamp-macro in datatypes.sql
