### PR TITLE
Update stage.sql, add default ldts value

### DIFF
--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -109,6 +109,11 @@
       {%- set include_source_columns = true -%}
     {%- endif -%}
 
+    {# If ldts is empty replace it with the current timestamp #}
+    {%- if datavault4dbt.is_nothing(ldts) -%}
+      {%- set ldts = datavault4dbt.current_timestamp() -%}
+    {%- endif -%}
+    
     {{- adapter.dispatch('stage', 'datavault4dbt')(include_source_columns=include_source_columns,
                                         ldts=ldts,
                                         rsrc=rsrc,


### PR DESCRIPTION
If no ldts is specified in the stage-macro-call the current timestamp will be used as value