### PR TITLE
Update hash.sql, remove hashdiff parameters from concattenated_standardise

### DIFF
--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -257,9 +257,9 @@
 {%- if is_hashdiff  and datavault4dbt.is_something(multi_active_key) -%}
     {%- set std_dict = fromjson(datavault4dbt.multi_active_concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key, multi_active_key=multi_active_key, main_hashkey_column=main_hashkey_column)) -%}
 {%- elif is_hashdiff -%}
-    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key,is_hashdiff=is_hashdiff, rtrim_hashdiff=rtrim_hashdiff)) -%}
+    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key)) -%}
 {%- else -%}
-    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashkey_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key,is_hashdiff=is_hashdiff, rtrim_hashdiff=rtrim_hashdiff)) -%}
+    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashkey_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key)) -%}
 {%- endif -%}
 
     {%- set standardise_prefix = std_dict['standardise_prefix'] -%}
@@ -325,9 +325,9 @@
 {%- if is_hashdiff  and datavault4dbt.is_something(multi_active_key) -%}
     {%- set std_dict = fromjson(datavault4dbt.multi_active_concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key, multi_active_key=multi_active_key, main_hashkey_column=main_hashkey_column)) -%}
 {%- elif is_hashdiff -%}
-    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key,is_hashdiff=is_hashdiff, rtrim_hashdiff=rtrim_hashdiff)) -%}
+    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key)) -%}
 {%- else -%}
-    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashkey_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key,is_hashdiff=is_hashdiff, rtrim_hashdiff=rtrim_hashdiff)) -%}
+    {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashkey_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key)) -%}
 {%- endif -%}
 
     {%- set standardise_prefix = std_dict['standardise_prefix'] -%}


### PR DESCRIPTION
Update hash.sql, remove hashdiff parameters from concattenated_standardise in redshift and postgres macros