### PR TITLE
Add Snowflake pit_type static string support

### DIFF
--- a/macros/tables/pit.sql
+++ b/macros/tables/pit.sql
@@ -12,8 +12,9 @@
 
     Parameters:
 
-    pit_type::string                    String to insert into the 'pit_type' column. Allows for future implementations of other
-                                        PIT variants, like T-PITs etc. Can be set freely, something like 'PIT' could be the default. 
+    pit_type::string                    String to insert into the 'pit_type' column. Has to be prefixed by a !.
+                                        Allows for future implementations of other PIT variants, like T-PITs etc.
+                                        Can be set freely, something like 'PIT' could be the default. 
                                         Is optional, if not set, no column will be added.
 
     tracked_entity::string              Name of the tracked Hub entity. Must be available as a model inside the dbt project.

--- a/macros/tables/snowflake/pit.sql
+++ b/macros/tables/snowflake/pit.sql
@@ -42,7 +42,7 @@ pit_records AS (
     SELECT
         
         {% if datavault4dbt.is_something(pit_type) -%}
-            '{{ datavault4dbt.as_constant(pit_type) }}' as type,
+            {{ datavault4dbt.as_constant(pit_type) }} as type,
         {%- endif %}
         {% if datavault4dbt.is_something(custom_rsrc) -%}
         '{{ custom_rsrc }}' as {{ rsrc }},


### PR DESCRIPTION
The snowflake pit-macro now correctly handles the pit_type-string when it is prefixed by a !.

Update the [Wiki](https://github.com/ScalefreeCOM/datavault4dbt/wiki/PIT) after merging. (add remark, that pit_type should be prefixed by !)