### PR TITLE
cast redshift string_to_timestamp-result to timestamp default datatype

### DIFF
--- a/macros/supporting/string_to_timestamp.sql
+++ b/macros/supporting/string_to_timestamp.sql
@@ -24,6 +24,6 @@
 {%- endmacro -%}
 
 {%- macro redshift__string_to_timestamp(format, timestamp) -%}
-    CAST(TO_TIMESTAMP('{{ timestamp }}', '{{ format }}') AS TIMESTAMP)
+    CAST(TO_TIMESTAMP('{{ timestamp }}', '{{ format }}') AS {{ datavault4dbt.timestamp_default_dtype() }})
 {%- endmacro -%}
 


### PR DESCRIPTION
[cast redshift string_to_timestamp-result to timestamp default datatype](https://github.com/ScalefreeCOM/datavault4dbt/commit/285214ac05174c02c781a526aee35c07c28f37b2)
This makes the timestamp datatype controllable by a global variable