### PR TITLE
business key is not listed in cte "source_new_union" when there is only one source per hub

### DIFF
--- a/macros/tables/redshift/hub.sql
+++ b/macros/tables/redshift/hub.sql
@@ -96,7 +96,7 @@ WITH
 
         {% endfor -%}
 
-        {%- if source_models | length > 1 %}
+        {%- if source_models | length > 0 %}
 
         rsrc_static_union AS (
             {#  Create one unionized table over all sources. It will be the same as the already existing


### PR DESCRIPTION
# Description

source_new_union is not listing the business key bk_ which is used in records_to_insert when only one source is used in a hub

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Redshift Adapter with a hub that was filled by only one Source.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
