### PR TITLE
fix hub key renaming if there are different namings for bk and hkey

### DIFF
--- a/macros/tables/bigquery/hub.sql
+++ b/macros/tables/bigquery/hub.sql
@@ -147,7 +147,7 @@ WITH
         SELECT
             {{ hk_column }} AS {{ hashkey }},
             {% for bk in source_model['bk_columns'] -%}
-            {{ bk }},
+            {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
             {{ src_ldts }},
@@ -188,7 +188,7 @@ source_new_union AS (
         {{ hashkey }},
 
         {% for bk in source_model['bk_columns'] -%}
-            {{ bk }} AS {{ business_keys[loop.index - 1] }},
+            {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
         {{ src_ldts }},

--- a/macros/tables/exasol/hub.sql
+++ b/macros/tables/exasol/hub.sql
@@ -145,7 +145,7 @@ WITH
         SELECT
             {{ hk_column }} AS {{ hashkey }},
             {% for bk in source_model['bk_columns'] -%}
-            {{ bk }},
+            {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
             {{ src_ldts }},
@@ -186,7 +186,7 @@ source_new_union AS (
         {{ hashkey }},
 
         {% for bk in source_model['bk_columns'] -%}
-            {{ bk }} AS {{ business_keys[loop.index - 1] }},
+            {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
         {{ src_ldts }},

--- a/macros/tables/postgres/hub.sql
+++ b/macros/tables/postgres/hub.sql
@@ -147,7 +147,7 @@ WITH
         SELECT
             {{ hk_column }} AS {{ hashkey }},
             {% for bk in source_model['bk_columns'] -%}
-            {{ bk }},
+            {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
             {{ src_ldts }},
@@ -188,7 +188,7 @@ source_new_union AS (
         {{ hashkey }},
 
         {% for bk in source_model['bk_columns'] -%}
-            {{ bk }} AS {{ business_keys[loop.index - 1] }},
+            {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
         {{ src_ldts }},

--- a/macros/tables/redshift/hub.sql
+++ b/macros/tables/redshift/hub.sql
@@ -147,7 +147,7 @@ WITH
         SELECT
             {{ hk_column }} AS {{ hashkey }},
             {% for bk in source_model['bk_columns'] -%}
-            {{ bk }},
+            {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
             {{ src_ldts }},
@@ -188,7 +188,7 @@ source_new_union AS (
         {{ hashkey }},
 
         {% for bk in source_model['bk_columns'] -%}
-            {{ bk }} AS {{ business_keys[loop.index - 1] }},
+            {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
         {{ src_ldts }},

--- a/macros/tables/synapse/hub.sql
+++ b/macros/tables/synapse/hub.sql
@@ -147,7 +147,7 @@ WITH
         SELECT
             {{ hk_column }} AS {{ hashkey }},
             {% for bk in source_model['bk_columns'] -%}
-            {{ bk }},
+            {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
             {{ src_ldts }},
@@ -188,7 +188,7 @@ source_new_union AS (
         {{ hashkey }},
 
         {% for bk in source_model['bk_columns'] -%}
-            {{ bk }} AS {{ business_keys[loop.index - 1] }},
+            {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
         {{ src_ldts }},


### PR DESCRIPTION
# Description

fix hub key renaming if there are different namings for bk and hkey in the `source_model:` and the staging-model itself and there is only one source model

When only one source_model is specified inside the staging-macro but the source_model key-namings are differing from the definitions in the staging model the renaming would only happen when there are more than one source-model selected.

Related PR with more context: #239 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing via skeleton-project.

# Checklist:

- [x] I have performed a self-review of my code