### PR TITLE
Update stage.sql, add default ldts value

### DIFF
--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -109,6 +109,11 @@
       {%- set include_source_columns = true -%}
     {%- endif -%}
 
+    {# If ldts is empty replace it with the current timestamp #}
+    {%- if datavault4dbt.is_nothing(ldts) -%}
+      {%- set ldts = datavault4dbt.current_timestamp() -%}
+    {%- endif -%}
+    
     {{- adapter.dispatch('stage', 'datavault4dbt')(include_source_columns=include_source_columns,
                                         ldts=ldts,
                                         rsrc=rsrc,


### PR DESCRIPTION
# Description

If no ldts is specified in the stage-macro-call the current timestamp will be used as value


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update -> This has been done already


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)

