### PR TITLE
Changing Google BigQuery to AWS Redshift

### DIFF
--- a/macros/staging/redshift/stage.sql
+++ b/macros/staging/redshift/stage.sql
@@ -1,4 +1,4 @@
-{# This is the default version of the stage macro, designed for Google BigQuery. #}
+{# This is the default version of the stage macro, designed for AWS Redshift. #}
 
 {%- macro redshift__stage(include_source_columns,
                 ldts,


### PR DESCRIPTION
# Description

Just a renaming issue for the stage macro from BigQuery to AWS Redshift

