### PR TITLE
Add CAST as timestamp_default_dtype to postgres__string_to_timestamp

### DIFF
--- a/macros/supporting/string_to_timestamp.sql
+++ b/macros/supporting/string_to_timestamp.sql
@@ -20,7 +20,7 @@
 {%- endmacro -%}
 
 {%- macro postgres__string_to_timestamp(format, timestamp) -%}
-    TO_TIMESTAMP('{{ timestamp }}', '{{ format }}')
+    CAST(TO_TIMESTAMP('{{ timestamp }}', '{{ format }}') AS {{ datavault4dbt.timestamp_default_dtype() }})
 {%- endmacro -%}
 
 {%- macro redshift__string_to_timestamp(format, timestamp) -%}


### PR DESCRIPTION
# Description

Add CAST as timestamp_default_dtype to postgres__string_to_timestamp.
Allows users to define their desired timestamp datatype