### PR TITLE
Cast postgres string to timestamp

### DIFF
--- a/macros/supporting/string_to_timestamp.sql
+++ b/macros/supporting/string_to_timestamp.sql
@@ -20,7 +20,7 @@
 {%- endmacro -%}
 
 {%- macro postgres__string_to_timestamp(format, timestamp) -%}
-    TO_TIMESTAMP('{{ timestamp }}', '{{ format }}')
+    CAST(TO_TIMESTAMP('{{ timestamp }}', '{{ format }}') AS {{ datavault4dbt.timestamp_default_dtype() }})
 {%- endmacro -%}
 
 {%- macro redshift__string_to_timestamp(format, timestamp) -%}


### PR DESCRIPTION
Update development branch
- [Add CAST to timestamp_default_dtype to postgres__string_to_timestamp](https://github.com/ScalefreeCOM/datavault4dbt/commit/acf923ec87d68f6472905eed8559da12f8193b2f)