### PR TITLE
run count instead of full scan for rec-trac-sats

### DIFF
--- a/macros/tables/bigquery/rec_track_sat.sql
+++ b/macros/tables/bigquery/rec_track_sat.sql
@@ -85,7 +85,7 @@ WITH
             {%- set source_in_target = true -%}
             
             {%- if execute -%}
-                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source_count) -%}
 
                 {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
 

--- a/macros/tables/exasol/rec_track_sat.sql
+++ b/macros/tables/exasol/rec_track_sat.sql
@@ -81,7 +81,7 @@ WITH
             {%- set source_in_target = true -%}
             
             {%- if execute -%}
-                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source_count) -%}
 
                 {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
 

--- a/macros/tables/synapse/rec_track_sat.sql
+++ b/macros/tables/synapse/rec_track_sat.sql
@@ -82,7 +82,7 @@ WITH
             {%- set source_in_target = true -%}
             
             {%- if execute -%}
-                {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
+                {%- set rsrc_static_result = run_query(rsrc_static_query_source_count) -%}
 
                 {%- set row_count = rsrc_static_result.columns[0].values()[0] -%}
 


### PR DESCRIPTION
# Description

Apply logic from https://github.com/ScalefreeCOM/datavault4dbt/commit/dfdb9182ef0a1dd688af6f517612ef51f9c85aa6 to the adapters where it is not present yet.
Prevents full table scanning and runs a count(*) instead

# Checklist:

- [x] I have performed a self-review of my code