### PR TITLE
Oracle clob hashing

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,6 +30,7 @@ vars:
   datavault4dbt.hash_datatype: 'STRING'
   datavault4dbt.hashkey_input_case_sensitive: FALSE
   datavault4dbt.hashdiff_input_case_sensitive: TRUE
+  datavault4dbt.clob_hashing: TRUE
   
   #Stage Configuration
   datavault4dbt.copy_rsrc_ldts_input_columns: false

--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -517,17 +517,19 @@
 {%- set concat_string = var('concat_string', '|') -%}
 {%- set quote = var('quote', '"') -%}
 {%- set null_placeholder_string = var('null_placeholder_string', '^^') -%}
+{%- set clob_hashing =  var('datavault4dbt.clob_hashing', FALSE) -%}
 
 {%- set hashkey_input_case_sensitive = var('datavault4dbt.hashkey_input_case_sensitive', FALSE) -%}
 {%- set hashdiff_input_case_sensitive = var('datavault4dbt.hashdiff_input_case_sensitive', TRUE) -%}
 
 {#- Select hashing algorithm -#}
-{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'VARCHAR2(40)') -%}
+{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'NVARCHAR2(40)') -%}
 {{ log('hash type in hash macro: ' ~ hash_dtype, false) }}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}
 {%- set unknown_key = hash_default_values['unknown_key'] -%}
 {%- set error_key = hash_default_values['error_key'] -%}
+
 
 {%- set attribute_standardise = datavault4dbt.attribute_standardise() %}
 
@@ -538,7 +540,9 @@
 
 {%- set all_null = [] -%}
 
-{%- if is_hashdiff  and datavault4dbt.is_something(multi_active_key) -%}
+{%- if is_hashdiff and datavault4dbt.is_something(multi_active_key) and clob_hashing -%}
+    {%- set std_dict = fromjson(datavault4dbt.multi_active_concattenated_standardise_CLOB(case_sensitive=hashdiff_input_case_sensitive, hash_alg='2', datatype=hash_dtype, alias=alias, zero_key=unknown_key, multi_active_key=multi_active_key, main_hashkey_column=main_hashkey_column)) -%}
+{%- elif is_hashdiff and datavault4dbt.is_something(multi_active_key) and not datavault4dbt.clob_hashing -%}
     {%- set std_dict = fromjson(datavault4dbt.multi_active_concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key, multi_active_key=multi_active_key, main_hashkey_column=main_hashkey_column)) -%}
 {%- elif is_hashdiff -%}
     {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key)) -%}

--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -523,7 +523,7 @@
 {%- set hashdiff_input_case_sensitive = var('datavault4dbt.hashdiff_input_case_sensitive', TRUE) -%}
 
 {#- Select hashing algorithm -#}
-{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'NVARCHAR2(40)') -%}
+{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'VARCHAR2(40)') -%}
 {{ log('hash type in hash macro: ' ~ hash_dtype, false) }}
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
 {%- set hash_alg = hash_default_values['hash_alg'] -%}

--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -985,3 +985,42 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
     {%- do dict_result.update({"standardise_suffix": standardise_suffix, "standardise_prefix": standardise_prefix }) -%}
     {{ return(dict_result | tojson ) }}
 {%- endmacro -%}
+
+{%- macro multi_active_concattenated_standardise_CLOB(case_sensitive, hash_alg, datatype, zero_key, alias, multi_active_key, main_hashkey_column) -%}
+
+{{ adapter.dispatch('multi_active_concattenated_standardise_CLOB', 'datavault4dbt')(case_sensitive=case_sensitive,
+                                                                              hash_alg=hash_alg,
+                                                                              datatype=datatype, 
+                                                                              zero_key=zero_key,
+                                                                              alias=alias,
+                                                                              multi_active_key=multi_active_key,
+                                                                              main_hashkey_column=main_hashkey_column) }}
+
+{%- endmacro -%}
+
+{%- macro oracle__multi_active_concattenated_standardise_CLOB(case_sensitive, hash_alg, datatype, zero_key, alias, multi_active_key, main_hashkey_column) -%}
+    {%- set dict_result = {} -%}
+    {%- set zero_key = datavault4dbt.as_constant(column_str=zero_key) -%}
+    {%- if multi_active_key is not string and multi_active_key is iterable -%}
+        {%- set multi_active_key = multi_active_key|join(", ") -%}
+    {%- endif -%}
+    {%- if case_sensitive -%}
+        {%- set standardise_prefix = "CAST(DBMS_CRYPTO.HASH(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(XMLCAST(XMLAGG(XMLELEMENT("'XMLNAME'","-%}
+                                      
+        {%- if alias is not none -%}
+            {%- set standardise_suffix = ")ORDER BY {}) as CLOB)), chr(10), '') , chr(9), ''), chr(11), '') , chr(13), ''), {}) AS VARCHAR2(40))  AS {} ".format(multi_active_key,hash_alg, alias) -%}
+        {%- else -%}
+            {%- set standardise_suffix = ")ORDER BY {}) as CLOB)), chr(10), '') , chr(9), ''), chr(11), '') , chr(13), ''), {}) AS VARCHAR2(40))  AS {} ".format(multi_active_key,hash_alg) -%}
+        {%- endif -%}
+    {%- else -%}
+        {%- set standardise_prefix = "DBMS_CRYPTO.HASH(REPLACE(REPLACE(REPLACE(REPLACE(XMLCAST(XMLAGG(XMLELEMENT("'XMLNAME'","-%}
+                                        
+        {%- if alias is not none -%}
+            {%- set standardise_suffix = ")ORDER BY {}) as CLOB), chr(10), '') , chr(9), ''), chr(11), '') , chr(13), ''), {}) AS VARCHAR2(40))  AS {} ".format(multi_active_key,hash_alg, alias) -%}
+        {%- else -%}
+            {%- set standardise_suffix = ")ORDER BY {}) as CLOB), chr(10), '') , chr(9), ''), chr(11), '') , chr(13), ''), {}) AS VARCHAR2(40))  AS {} ".format(multi_active_key,hash_alg) -%}
+        {%- endif -%}
+    {%- endif -%}
+    {%- do dict_result.update({"standardise_suffix": standardise_suffix, "standardise_prefix": standardise_prefix }) -%}
+    {{ return(dict_result | tojson ) }}
+{%- endmacro -%}


### PR DESCRIPTION
# Description

Added Oracle Clob Hashing to the Oracle adapter for multiactive hashdiffs that are larger then 32000 bytes

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ALL ] Tests you ran

**Test Configuration**:
* datavault4dbt-Version: 1.7.2
* dbt-Version: core, version number_ 1.8.0
* dbt-adapter-Version: 1.8.0

# Checklist:

- [ x] I have performed a self-review of my code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
