### PR TITLE
Feature: extract multiple columns from one prejoined object

### DIFF
--- a/macros/internal/helpers/stage_processing_macros.sql
+++ b/macros/internal/helpers/stage_processing_macros.sql
@@ -167,7 +167,14 @@
 
                 {% set tmp_dict %}
                 {{dict_key}}:
+                    {%- if 'ref_model' in dict_item.keys()|map('lower') %}
                     ref_model: {{dict_item.ref_model}}
+                    {%- elif 'src_name' in dict_item.keys()|map('lower') and 'src_table' in dict_item.keys()|map('lower') %}
+                    src_name: {{dict_item.src_name}}
+                    src_table: {{dict_item.src_table}}
+                    {%- else %}
+                        {{ exceptions.raise_compiler_error("Either ref_model or src_name and src_table have to be defined for each prejoin") }}
+                    {%- endif %}
                     bk: {{dict_item.extract_columns[loop.index0]}}
                     this_column_name: {{dict_item.this_column_name}}
                     ref_column_name: {{dict_item.ref_column_name}}
@@ -192,7 +199,14 @@
 
             {% set tmp_dict %}
             {{dict_key}}:
+                {%- if 'ref_model' in dict_item.keys()|map('lower') %}
                 ref_model: {{dict_item.ref_model}}
+                {%- elif 'src_name' in dict_item.keys()|map('lower') and 'src_table' in dict_item.keys()|map('lower') %}
+                src_name: {{dict_item.src_name}}
+                src_table: {{dict_item.src_table}}
+                {%- else %}
+                    {{ exceptions.raise_compiler_error("Either ref_model or src_name and src_table have to be defined for each prejoin") }}
+                {%- endif %}
                 bk: {{dict_item.extract_columns[loop.index0]}}
                 this_column_name: {{dict_item.this_column_name}}
                 ref_column_name: {{dict_item.ref_column_name}}

--- a/macros/internal/helpers/stage_processing_macros.sql
+++ b/macros/internal/helpers/stage_processing_macros.sql
@@ -145,7 +145,8 @@
         {# If column aliases are present they they have to map 1:1 to the extract_columns #}
         {% if datavault4dbt.is_something(dict_item.aliases) 
             and not dict_item.aliases|length ==  dict_item.extract_columns|length %}
-            {{ exceptions.raise_compiler_error("Prejoin aliases must have the same length as extract_columns") }}
+            {{ exceptions.raise_compiler_error("Prejoin aliases must have the same length as extract_columns. Got "
+             ~ dict_item.extract_columns|length ~ " extract_columns and " ~ dict_item.aliases|length ~ " aliases.") }}
         {% endif %}
 
         {# If multiple columns from the same source should be extracted each column has to be processed once #}

--- a/macros/internal/helpers/stage_processing_macros.sql
+++ b/macros/internal/helpers/stage_processing_macros.sql
@@ -144,7 +144,7 @@
 
         {# If column aliases are present they they have to map 1:1 to the extract_columns #}
         {% if datavault4dbt.is_something(dict_item.aliases) 
-            and not dict_item.aliases|length ==  dict_item.extract_columns|length%}
+            and not dict_item.aliases|length ==  dict_item.extract_columns|length %}
             {{ exceptions.raise_compiler_error("Prejoin aliases must have the same length as extract_columns") }}
         {% endif %}
 
@@ -154,15 +154,20 @@
                 {# If aliases are defined they should be used as dict keys
                 These will be used as new column names #}
                 {% if datavault4dbt.is_something(dict_item.aliases) %}
-                    {% set dict_key = dict_item.aliases[loop.index-1] %}
+                    {% set dict_key = dict_item.aliases[loop.index0] %}
                 {% else %}
-                    {% set dict_key = dict_item.extract_columns[loop.index-1] %}
+                    {% set dict_key = dict_item.extract_columns[loop.index0] %}
+                {% endif %}
+
+                {# To make sure each column or alias is present only once #}
+                {% if dict_key|lower in return_dict.keys()|map('lower') %}
+                    {{ exceptions.raise_compiler_error("Prejoined Column name or alias '" ~ dict_key ~ "' is defined twice.") }}
                 {% endif %}
 
                 {% set tmp_dict %}
                 {{dict_key}}:
                     ref_model: {{dict_item.ref_model}}
-                    bk: {{dict_item.extract_columns[loop.index-1]}}
+                    bk: {{dict_item.extract_columns[loop.index0]}}
                     this_column_name: {{dict_item.this_column_name}}
                     ref_column_name: {{dict_item.ref_column_name}}
                 {% endset %}
@@ -174,15 +179,20 @@
             {# If aliases are defined they should be used as dict keys
             These will be used as new column names #}
             {% if datavault4dbt.is_something(dict_item.aliases) %}
-                {% set dict_key = dict_item.aliases[loop.index-1] %}
+                {% set dict_key = dict_item.aliases[loop.index0] %}
             {% else %}
-                {% set dict_key = dict_item.extract_columns[loop.index-1] %}
+                {% set dict_key = dict_item.extract_columns[loop.index0] %}
+            {% endif %}
+
+            {# To make sure each column or alias is present only once #}
+            {% if dict_key|lower in return_dict.keys()|map('lower') %}
+                {{ exceptions.raise_compiler_error("Prejoined Column name or alias '" ~ dict_key ~ "' is defined twice.") }}
             {% endif %}
 
             {% set tmp_dict %}
             {{dict_key}}:
                 ref_model: {{dict_item.ref_model}}
-                bk: {{dict_item.extract_columns[loop.index-1]}}
+                bk: {{dict_item.extract_columns[loop.index0]}}
                 this_column_name: {{dict_item.this_column_name}}
                 ref_column_name: {{dict_item.ref_column_name}}
             {% endset %}

--- a/macros/staging/bigquery/stage.sql
+++ b/macros/staging/bigquery/stage.sql
@@ -256,6 +256,7 @@ missing_columns AS (
 ),
 {%- endif -%}
 
+
 {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
@@ -263,14 +264,12 @@ prejoined_columns AS (
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS {{ col }}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -309,15 +308,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '`' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '`' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 

--- a/macros/staging/databricks/stage.sql
+++ b/macros/staging/databricks/stage.sql
@@ -253,6 +253,7 @@ missing_columns AS (
 ),
 {%- endif -%}
 
+
 {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
@@ -260,14 +261,12 @@ prejoined_columns AS (
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS {{ col }}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -306,18 +305,31 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '`' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '`' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
-
 
 {%- if datavault4dbt.is_something(derived_columns) %}
 {# Adding derived columns to the selection #}

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -244,6 +244,7 @@ missing_columns AS (
 ),
 {%- endif -%}
 
+
 {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
@@ -251,14 +252,12 @@ prejoined_columns AS (
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS "{{ col | upper }}"
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -297,15 +296,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '"' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '"' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 

--- a/macros/staging/fabric/stage.sql
+++ b/macros/staging/fabric/stage.sql
@@ -253,23 +253,21 @@ missing_columns AS (
 ),
 {%- endif -%}
 
-{%- if datavault4dbt.is_something(prejoined_columns) %}
 
-{%- set final_columns_to_select = (final_columns_to_select + derived_input_columns) | unique | list -%}
+{%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
+
 prejoined_columns AS (
 
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{datavault4dbt.escape_column_names(vals['bk'])}} AS {{datavault4dbt.escape_column_names(col)}}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -308,15 +306,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=datavault4dbt.escape_column_names(vals['this_column_name']), prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=datavault4dbt.escape_column_names(vals['ref_column_name'])) }}
+    {%- set prejoin_hash = '"' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '"' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 

--- a/macros/staging/oracle/stage.sql
+++ b/macros/staging/oracle/stage.sql
@@ -263,6 +263,7 @@ missing_columns AS (
 ),
 {%- endif -%}
 
+
 {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
@@ -270,14 +271,12 @@ prejoined_columns AS (
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS {{ col }}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -316,15 +315,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '"' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '"' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 

--- a/macros/staging/postgres/stage.sql
+++ b/macros/staging/postgres/stage.sql
@@ -256,6 +256,7 @@ missing_columns AS (
 ),
 {%- endif -%}
 
+
 {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
@@ -263,14 +264,12 @@ prejoined_columns AS (
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS {{ col }}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -309,15 +308,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '"' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '"' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 

--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -263,6 +263,7 @@ missing_columns AS (
 ),
 {%- endif -%}
 
+
 {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
@@ -270,14 +271,12 @@ prejoined_columns AS (
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS {{ col }}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -316,15 +315,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '"' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '"' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 

--- a/macros/staging/stage.sql
+++ b/macros/staging/stage.sql
@@ -120,6 +120,11 @@
     {%- if datavault4dbt.is_nothing(ldts) -%}
       {%- set ldts = datavault4dbt.current_timestamp() -%}
     {%- endif -%}
+
+    {# To parse the list syntax of prejoined columns #}
+    {%- if datavault4dbt.is_something(prejoined_columns) -%}
+      {%- set prejoined_columns = datavault4dbt.process_prejoined_columns(prejoined_columns) -%}
+    {%- endif -%}
     
     {{- adapter.dispatch('stage', 'datavault4dbt')(include_source_columns=include_source_columns,
                                         ldts=ldts,

--- a/macros/staging/synapse/stage.sql
+++ b/macros/staging/synapse/stage.sql
@@ -255,23 +255,20 @@ missing_columns AS (
 ),
 {%- endif -%}
 
-{%- if datavault4dbt.is_something(prejoined_columns) %}
 
-{%- set final_columns_to_select = (final_columns_to_select + derived_input_columns) | unique | list -%}
+{%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
 
   SELECT
   {% if final_columns_to_select | length > 0 -%}
     {{ datavault4dbt.print_list(datavault4dbt.prefix(columns=datavault4dbt.escape_column_names(final_columns_to_select), prefix_str='lcte').split(',')) }}
-  {% endif %}
+  {%- endif -%}
+
+ {#-  prepare join statements -#}
+  {%- set prejoin_statements_list = [] -%}
+  {%- set processed_prejoin_hashes = [] -%}
   {%- for col, vals in prejoined_columns.items() -%}
-    ,pj_{{loop.index}}.{{ vals['bk'] }} AS {{ col }}
-  {% endfor -%}
-
-  FROM {{ last_cte }} lcte
-
-  {% for col, vals in prejoined_columns.items() %}
 
     {%- if 'src_name' in vals.keys() or 'src_table' in vals.keys() -%}
       {%- set relation = source(vals['src_name']|string, vals['src_table']) -%}
@@ -310,15 +307,29 @@ prejoined_columns AS (
       {%- set operator = vals['operator'] -%}
     {%- endif -%}
 
-    {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
-    left join {{ relation }} as {{ prejoin_alias }} 
-      on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+    {%- set prejoin_hash = '"' ~ local_md5(relation~vals['this_column_name']~operator~vals['ref_column_name']) ~ '"' -%}
 
-  {% endfor %}
+    {%- if not prejoin_hash in processed_prejoin_hashes  %}
+      {%- do processed_prejoin_hashes.append(prejoin_hash) %}
+      {%- set prejoin_join_statement_tmp -%}
+        left join {{ relation }} as {{ prejoin_hash }} 
+        on {{ datavault4dbt.multikey(columns=vals['this_column_name'], prefix=['lcte', prejoin_hash], condition='=', operator=operator, right_columns=vals['ref_column_name']) }}
+
+      {% endset -%}
+      {%- do prejoin_statements_list.append(prejoin_join_statement_tmp) -%}
+    {%- endif -%}
+   
+{# select the prejoined columns #}
+    ,{{prejoin_hash}}.{{ vals['bk'] }} AS {{ col }}
+  {% endfor -%}
+
+  FROM {{ last_cte }} lcte
+
+  {{ prejoin_statements_list|join(' ')}}
 
   {% set last_cte = "prejoined_columns" -%}
-  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names %}
+  {%- set final_columns_to_select = final_columns_to_select + prejoined_column_names -%}
 ),
 {%- endif -%}
 


### PR DESCRIPTION
# Description

Change prejoin-processing to only produce one left join for each unique combination of relation, columns and operator.

Also add new syntax for prejoins, allowing extraction of multiple columns from the same prejoin-source:

```
  prejoined_columns:
      - extract_columns: 
           - id
           - number
        aliases:
           - businessid
           - businessnumber
        ref_model: 'business_raw'
        this_column_name: 'ContractId'
        ref_column_name: 'ContractId'
```
In this example we join the source model with `business_raw` and extract `id` and `number` and assign an alias for each column.
Assigning an alias is optional, but if done, the number of `extract_columns` has to match the amount of `aliases`.
For each prejoin-target a new list, containing at least a dictionary for extract_columns and values for ref_model(or source_name & source_table) and the column names, needs to be defined. 

The old syntax is still valid and can be used if desired.


Fixes https://github.com/ScalefreeCOM/datavault4dbt/issues/287

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates

### ToDO: Update [Docs](https://www.datavault4dbt.com/documentation/macro-instructions/staging/prejoining/) to include the new syntax and additionally include information about `aliases`
