### PR TITLE
Upper/Lower Case support for Databricks column names

### DIFF
--- a/macros/internal/metadata_processing/escape_column_names.sql
+++ b/macros/internal/metadata_processing/escape_column_names.sql
@@ -192,7 +192,12 @@
     {%- set escape_char_left  = var('escape_char_left',  "") -%}
     {%- set escape_char_right = var('escape_char_right', "") -%}
 
-    {%- set escaped_column_name = escape_char_left ~ column | upper | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
+        {%- set escaped_column_name = escape_char_left ~ column | upper | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
+    {% elif set_casing|lower in ['lower', 'lowercase'] %}
+        {%- set escaped_column_name = escape_char_left ~ column | lower | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
+    {% endif %}
 
     {%- do return(escaped_column_name) -%}
 


### PR DESCRIPTION
# Note
DRAFT: Waiting on additional change to `sat_v1` macro to also set case here too

# Description
- Currently all columns default to uppercase, this change allows setting the default case for column names on the Databricks adapter to either upper or lower case based on a variable (Matches Fabric Functionality)

Existing Fabric Functionality - https://github.com/ScalefreeCOM/datavault4dbt/blob/main/macros/internal/metadata_processing/escape_column_names.sql#L171-L187

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Tests you ran

Reproducing the functionality
- Created standard Databricks model (Staging Table)
- Run the Model
- All column will default to be upper case (As expected)
- Set the `datavault4dbt.set_casing` to `lower`
- Run the Model
- All columns will now be lower case

**Test Configuration**:
* datavault4dbt-Version: 1.8.1
* dbt-Version: 1.8.8/core
* dbt-adapter-Version: 1.8.1

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
