### PR TITLE
Redshift: Use QUALIFY statement instead of prep-CTEs to enhance performance

### DIFF
--- a/macros/tables/redshift/eff_sat_v0.sql
+++ b/macros/tables/redshift/eff_sat_v0.sql
@@ -130,13 +130,13 @@ current_status AS (
     deduplicated_incoming AS (
 
         SELECT
-            is_active.{{ tracked_hashkey }},
-            is_active.{{ src_ldts }},
-            is_active.{{ is_active_alias }}
-        FROM is_active redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
+            ia.{{ tracked_hashkey }},
+            ia.{{ src_ldts }},
+            ia.{{ is_active_alias }}
+        FROM is_active ia
         QUALIFY 
             CASE 
-                WHEN is_active.{{ is_active_alias }} = LAG(is_active.{{ is_active_alias }}) OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
+                WHEN ia.{{ is_active_alias }} = LAG(ia.{{ is_active_alias }}) OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
                 ELSE TRUE
             END
 

--- a/macros/tables/redshift/eff_sat_v0.sql
+++ b/macros/tables/redshift/eff_sat_v0.sql
@@ -49,23 +49,13 @@ source_data AS (
     In all incremental cases, the current status for each hashkey is selected from the existing Effectivity Satellite.
 #}
 {%- if is_incremental() %}
-current_status_prep AS (
-
-    SELECT
-        {{ tracked_hashkey }},
-        {{ is_active_alias}},
-        ROW_NUMBER() OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM {{ this }}
-
-),
-
 current_status AS (
 
     SELECT
         {{ tracked_hashkey }},
         {{ is_active_alias }}
-    FROM current_status_prep
-    WHERE rn = 1 
+    FROM {{ this }} redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1  
 
 ),
 {% endif %}
@@ -136,32 +126,19 @@ current_status AS (
 
     {#
         The rows are deduplicated on the is_active_alias, to only include status changes. 
-        Additionally, a ROW_NUMBER() is calculated in incremental runs, to use it in the next step for comparison against the current status.
     #}
-    deduplicated_incoming_prep AS (
+    deduplicated_incoming AS (
 
         SELECT
             is_active.{{ tracked_hashkey }},
             is_active.{{ src_ldts }},
-            is_active.{{ is_active_alias }},
-            LAG(is_active.{{ is_active_alias }}) OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }}) as lag_is_active
-
-        FROM is_active
-
-    ),
-
-    deduplicated_incoming AS (
-
-        SELECT
-            deduplicated_incoming_prep.{{ tracked_hashkey }},
-            deduplicated_incoming_prep.{{ src_ldts }},
-            deduplicated_incoming_prep.{{ is_active_alias }}
-
-        FROM
-            deduplicated_incoming_prep
-        WHERE
-            deduplicated_incoming_prep.{{ is_active_alias }} != deduplicated_incoming_prep.lag_is_active
-            OR deduplicated_incoming_prep.lag_is_active IS NULL
+            is_active.{{ is_active_alias }}
+        FROM is_active redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
+        QUALIFY 
+            CASE 
+                WHEN is_active.{{ is_active_alias }} = LAG(is_active.{{ is_active_alias }}) OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
+                ELSE TRUE
+            END
 
     ),
 

--- a/macros/tables/redshift/link.sql
+++ b/macros/tables/redshift/link.sql
@@ -210,21 +210,17 @@ source_new_union AS (
 
 {%- endif %}
 
-earliest_hk_over_all_sources_prep AS (
-    SELECT
-        lcte.*,
-        ROW_NUMBER() OVER (PARTITION BY {{ link_hashkey }} ORDER BY {{ src_ldts
-        }}) as rn
-    FROM {{ ns.last_cte }} AS lcte),
-
 earliest_hk_over_all_sources AS (
 
     {#- Deduplicate the unionized records again to only insert the earliest one. #}
     SELECT
         lcte.*
-    FROM earliest_hk_over_all_sources_prep AS lcte
-        WHERE rn = 1
-    {%- set ns.last_cte = 'earliest_hk_over_all_sources' -%}),
+    FROM {{ ns.last_cte }} AS lcte
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY {{ link_hashkey }} ORDER BY {{ src_ldts }}) = 1
+
+    {%- set ns.last_cte = 'earliest_hk_over_all_sources' -%}
+
+),
 
 records_to_insert AS (
     {# Select everything from the previous CTE, if incremental filter for hashkeys that are not already in the link. #}

--- a/macros/tables/redshift/nh_link.sql
+++ b/macros/tables/redshift/nh_link.sql
@@ -226,21 +226,17 @@ source_new_union AS (
 
 {%- if not source_is_single_batch %}
 
-earliest_hk_over_all_sources_prep AS (
-    SELECT
-        lcte.*,
-        ROW_NUMBER() OVER (PARTITION BY {{ link_hashkey }} ORDER BY {{ src_ldts
-        }}) as rn
-    FROM {{ ns.last_cte }} AS lcte),
-
 earliest_hk_over_all_sources AS (
 
-    {#- Deduplicate the unionized records again to only insert the earliest one. #}
+{#- Deduplicate the unionized records again to only insert the earliest one. #}
     SELECT
         lcte.*
-    FROM earliest_hk_over_all_sources_prep AS lcte
-        WHERE rn = 1
-    {%- set ns.last_cte = 'earliest_hk_over_all_sources' -%}),
+    FROM {{ ns.last_cte }} AS lcte
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY {{ link_hashkey }} ORDER BY {{ src_ldts }}) = 1
+
+    {%- set ns.last_cte = 'earliest_hk_over_all_sources' -%}
+
+),
 
 {%- endif %}
 


### PR DESCRIPTION
# Description

All macros that need to get the latest existing records now use QUALIFY instead of an additional CTE with ROW_NUMBER() and WHERE. This massively boosts performance.

Fixes #298 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
