### PR TITLE
add adapter dispatch to process_columns_to_select

### DIFF
--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -1,4 +1,11 @@
 {%- macro process_columns_to_select(columns_list=none, exclude_columns_list=none) -%}
+
+    {{ return(adapter.dispatch('process_columns_to_select', 'datavault4dbt')(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__process_columns_to_select(columns_list, exclude_columns_list) -%}
     {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
     {% set columns_list = columns_list | map('upper') | list %}
     {% set columns_to_select = [] %}


### PR DESCRIPTION
# Description

add adapter dispatch to process_columns_to_select so it can be overridden by users

Fixes #307 

# How Has This Been Tested?

https://github.com/ScalefreeCOM/datavault4dbt-ci-cd/actions/runs/12913086057/job/36009629640
