### PR TITLE
add md5-binary support for snowflake

### DIFF
--- a/macros/supporting/hash_default_values.sql
+++ b/macros/supporting/hash_default_values.sql
@@ -46,6 +46,10 @@
         {%- set hash_alg = 'MD5' -%}
         {%- set unknown_key = '!00000000000000000000000000000000' -%}
         {%- set error_key = '!ffffffffffffffffffffffffffffffff' -%}
+    {%- elif (hash_function == 'MD5' or hash_function == 'MD5_BINARY') and hash_datatype == 'BINARY' -%}
+        {%- set hash_alg = 'MD5_BINARY' -%}
+        {%- set unknown_key = "TO_BINARY('0000000000000000000000000000000000000000')" -%}
+        {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffffffffffff')" -%}
     {%- elif hash_function == 'SHA1' or hash_function == 'SHA1_HEX' or hash_function == 'SHA' -%} 
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
             {%- set hash_alg = 'SHA1' -%}

--- a/macros/tables/snowflake/rec_track_sat.sql
+++ b/macros/tables/snowflake/rec_track_sat.sql
@@ -32,7 +32,7 @@ WITH
 {% if is_incremental() %}
 
     distinct_concated_target AS (
-        {%- set concat_columns = [tracked_hashkey, src_ldts, src_rsrc] -%}
+        {%- set concat_columns = ["CAST(" ~ tracked_hashkey ~ " AS STRING)", src_ldts, src_rsrc] -%}
         {{ "\n" }}
         SELECT
         {{ datavault4dbt.concat_ws(concat_columns) }} as concat


### PR DESCRIPTION
# Description

add md5_binary to the supported algorithms for the snowflake hash_default_values
Also include a fix for the record tracking satellite because the snowflake CONCAT() function does not allow binary and string in the same statement

Fixes #306 