### PR TITLE
add optional refer_to_ghost_records parameter to pit macros

### DIFF
--- a/macros/tables/bigquery/pit.sql
+++ b/macros/tables/bigquery/pit.sql
@@ -1,4 +1,4 @@
-{%- macro default__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro default__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
@@ -57,8 +57,13 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
             {{- "," if not loop.last }}
         {%- endfor %}
 

--- a/macros/tables/databricks/pit.sql
+++ b/macros/tables/databricks/pit.sql
@@ -1,4 +1,4 @@
-{%- macro databricks__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro databricks__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
@@ -57,9 +57,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -1,4 +1,4 @@
-{%- macro exasol__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro exasol__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'HASHTYPE') -%}
@@ -53,9 +53,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/fabric/pit.sql
+++ b/macros/tables/fabric/pit.sql
@@ -1,4 +1,4 @@
-{%- macro fabric__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro fabric__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'VARBINARY(16)') -%}
@@ -60,9 +60,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {%- for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS {{datavault4dbt.escape_column_names('hk_'~ satellite)}},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ datavault4dbt.escape_column_names(ldts~'_'~satellite)}}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS {{datavault4dbt.escape_column_names('hk_'~ satellite)}},
+            {{ satellite }}.{{ ldts }} AS {{ datavault4dbt.escape_column_names(ldts~'_'~satellite)}}
+          {% endif %}
+          {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/oracle/pit.sql
+++ b/macros/tables/oracle/pit.sql
@@ -1,4 +1,4 @@
-{%- macro oracle__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro oracle__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'VARCHAR2(40)') -%}
@@ -53,9 +53,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {%- for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/pit.sql
+++ b/macros/tables/pit.sql
@@ -11,7 +11,7 @@
         - Allows to insert a static string as record source column, matching business vault definition of a record source
 #}
 
-{%- macro pit(yaml_metadata=none, tracked_entity=none, hashkey=none, sat_names=none, snapshot_relation=none, dimension_key=none, snapshot_trigger_column=none, ldts=none, custom_rsrc=none, ledts=none, sdts=none, pit_type=none) -%}
+{%- macro pit(yaml_metadata=none, tracked_entity=none, hashkey=none, sat_names=none, snapshot_relation=none, dimension_key=none, snapshot_trigger_column=none, ldts=none, custom_rsrc=none, ledts=none, sdts=none, pit_type=none, refer_to_ghost_records=True) -%}
 
     {% set tracked_entity_description = "
     tracked_entity::string              Name of the tracked Hub entity. Must be available as a model inside the dbt project.
@@ -70,6 +70,11 @@
                                         Is optional, if not set, no column will be added.
     " %}
 
+    {% set refer_to_ghost_records_description = "
+    refer_to_ghost_records::boolean     Value to define if a NULL satellite hashkey should be replaced by the unknown key.
+                                        Optional parameter, default is True.
+    " %}
+
     {%- set tracked_entity          = datavault4dbt.yaml_metadata_parser(name='tracked_entity', yaml_metadata=yaml_metadata, parameter=tracked_entity, required=True, documentation=tracked_entity_description) -%}
     {%- set hashkey                 = datavault4dbt.yaml_metadata_parser(name='hashkey', yaml_metadata=yaml_metadata, parameter=hashkey, required=True, documentation=hashkey_description) -%}
     {%- set sat_names               = datavault4dbt.yaml_metadata_parser(name='sat_names', yaml_metadata=yaml_metadata, parameter=sat_names, required=True, documentation=sat_names_description) -%}
@@ -81,6 +86,7 @@
     {%- set ledts                   = datavault4dbt.yaml_metadata_parser(name='ledts', yaml_metadata=yaml_metadata, parameter=ledts, required=False, documentation=ledts_description) -%}
     {%- set sdts                    = datavault4dbt.yaml_metadata_parser(name='sdts', yaml_metadata=yaml_metadata, parameter=sdts, required=False, documentation=sdts_description) -%}
     {%- set pit_type                = datavault4dbt.yaml_metadata_parser(name='pit_type', yaml_metadata=yaml_metadata, parameter=pit_type, required=False, documentation=pit_type_description) -%}
+    {%- set refer_to_ghost_records  = datavault4dbt.yaml_metadata_parser(name='refer_to_ghost_records', yaml_metadata=yaml_metadata, parameter=refer_to_ghost_records, required=False, documentation=pit_type_description) -%}
 
     {# Applying the default aliases as stored inside the global variables, if ldts, sdts and ledts are not set. #}
 
@@ -98,6 +104,7 @@
                                                         ledts=ledts,
                                                         snapshot_relation=snapshot_relation,
                                                         snapshot_trigger_column=snapshot_trigger_column,
-                                                        dimension_key=dimension_key)) }}
+                                                        dimension_key=dimension_key,
+                                                        refer_to_ghost_records=refer_to_ghost_records)) }}
 
 {%- endmacro -%}

--- a/macros/tables/postgres/pit.sql
+++ b/macros/tables/postgres/pit.sql
@@ -1,4 +1,4 @@
-{%- macro postgres__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro postgres__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'VARCHAR(32)') -%}
@@ -57,9 +57,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/redshift/pit.sql
+++ b/macros/tables/redshift/pit.sql
@@ -1,4 +1,4 @@
-{%- macro redshift__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro redshift__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'VARCHAR(32)') -%}
@@ -58,9 +58,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/snowflake/pit.sql
+++ b/macros/tables/snowflake/pit.sql
@@ -1,4 +1,4 @@
-{%- macro snowflake__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro snowflake__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = datavault4dbt.hash_method() -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
@@ -53,9 +53,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {%- for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM

--- a/macros/tables/synapse/pit.sql
+++ b/macros/tables/synapse/pit.sql
@@ -1,4 +1,4 @@
-{%- macro synapse__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none) -%}
+{%- macro synapse__pit(tracked_entity, hashkey, sat_names, ldts, ledts, sdts, snapshot_relation, dimension_key,snapshot_trigger_column=none, custom_rsrc=none, pit_type=none, refer_to_ghost_records) -%}
 
 {%- set hash = var('datavault4dbt.hash', 'MD5') -%}
 {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'BINARY(16)') -%}
@@ -53,9 +53,14 @@ pit_records AS (
         te.{{ hashkey }},
         snap.{{ sdts }},
         {%- for satellite in sat_names %}
+          {% if refer_to_ghost_records %}
             COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
             COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
-            {{- "," if not loop.last }}
+          {% else %}
+            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
+            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+          {% endif %}
+        {{- "," if not loop.last }}
         {%- endfor %}
 
     FROM


### PR DESCRIPTION
# Description

Add optional parameter to pit macro which determines if for `null` satellite hashkeys the ghost record should be referenced. Default is true, same as the old behavior