### PR TITLE
Adding Upper/Lower case field naming support for Databricks

### DIFF
--- a/macros/internal/metadata_processing/escape_column_names.sql
+++ b/macros/internal/metadata_processing/escape_column_names.sql
@@ -194,6 +194,13 @@
 
     {%- set escaped_column_name = escape_char_left ~ column | upper | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
 
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
+        {%- set escaped_column_name = escaped_column_name | upper -%}
+    {% elif set_casing|lower in ['lower', 'lowercase'] %}
+        {%- set escaped_column_name = escaped_column_name | lower -%}
+    {% endif %}
+
     {%- do return(escaped_column_name) -%}
 
 {%- endmacro -%}

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -69,6 +69,42 @@
 {%- endmacro -%}
 
 
+{%- macro databricks__process_columns_to_select(columns_list, exclude_columns_list) -%}
+
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
+        {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
+        {% set columns_list = columns_list | map('upper') | list %}
+    {% elif set_casing|lower in ['lower', 'lowercase'] %}
+        {% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
+        {% set columns_list = columns_list | map('lower') | list %}
+    {% endif %}
+
+    {% set columns_to_select = [] %}
+
+    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
+
+        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+
+    {%- endif -%}
+
+    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+        {%- for col in columns_list -%}
+
+            {%- if col not in exclude_columns_list -%}
+                {%- do columns_to_select.append(col) -%}
+            {%- endif -%}
+
+        {%- endfor -%}
+    {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
+        {% set columns_to_select = columns_list %}
+    {%- endif -%}
+
+    {%- do return(columns_to_select) -%}
+
+{%- endmacro -%}
+
+
 {%- macro extract_column_names(columns_dict=none) -%}
 
     {%- set extracted_column_names = [] -%}

--- a/macros/tables/databricks/ma_sat_v1.sql
+++ b/macros/tables/databricks/ma_sat_v1.sql
@@ -4,6 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(sat_v0) -%}
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}

--- a/macros/tables/databricks/ref_sat_v1.sql
+++ b/macros/tables/databricks/ref_sat_v1.sql
@@ -4,6 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 

--- a/macros/tables/databricks/sat_v1.sql
+++ b/macros/tables/databricks/sat_v1.sql
@@ -4,6 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(sat_v0) -%}
 

--- a/macros/tables/fabric/sat_v1.sql
+++ b/macros/tables/fabric/sat_v1.sql
@@ -3,7 +3,8 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'is_current') -%}
+{%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(sat_v0) -%}
 


### PR DESCRIPTION
# Description
- Adds Databricks support for upper & lower case column names via the `datavault4dbt.set_casing` variable. 
Replicates the existing implementation that was recently implemented for Fabric providers

- Includes `is_current` set_casing support for the bug mentioned below for Databricks provider
- Includes `is_current` set_casing support for sat_v1 object for the Fabric provider to match case settings for existing Fabric ma_sat_v1 & ref_sat_v1 objects.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- The existing Fabric implemented was replicated 
- Each of the Datavault specific table types was tested and verified that they produced upper or lower case field names depending on the setting

**Test Configuration**:
* datavault4dbt-Version: 1.92
* dbt-Version: core, version number_1.9.2
* dbt-adapter-Version: 1.9.2

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
