### PR TITLE
[Fabric] Move prepend generated by after first with to allow data preview

### DIFF
--- a/macros/staging/fabric/stage.sql
+++ b/macros/staging/fabric/stage.sql
@@ -177,9 +177,9 @@
 {#- Setting the rsrc default datatype -#}
 {%- set rsrc_default_dtype = datavault4dbt.string_default_dtype(type=rsrc) -%}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {# Selecting everything that we need from the source relation. #}
 source_data AS (

--- a/macros/tables/fabric/eff_sat_v0.sql
+++ b/macros/tables/fabric/eff_sat_v0.sql
@@ -16,9 +16,9 @@
 
 {{ log('columns to select: '~final_columns_to_select, false) }}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH 
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {#
     In all cases, the source model is selected, and optionally a HWM is applied. 

--- a/macros/tables/fabric/hub.sql
+++ b/macros/tables/fabric/hub.sql
@@ -31,9 +31,10 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 
-{{ datavault4dbt.prepend_generated_by() }}
 
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {% if is_incremental() -%}
 {# Get all target hashkeys out of the existing hub for later incremental logic. #}

--- a/macros/tables/fabric/link.sql
+++ b/macros/tables/fabric/link.sql
@@ -34,9 +34,9 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {% if is_incremental() %}
 {# Get all link hashkeys out of the existing link for later incremental logic. #}

--- a/macros/tables/fabric/ma_sat_v0.sql
+++ b/macros/tables/fabric/ma_sat_v0.sql
@@ -26,11 +26,13 @@
 {%- set src_payload = datavault4dbt.escape_column_names(src_payload) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
-
-{{ datavault4dbt.prepend_generated_by() }}
  
 {# Selecting all source data, that is newer than latest data in sat if incremental #}
-WITH source_data AS (
+WITH 
+
+{{ datavault4dbt.prepend_generated_by() }}
+
+source_data AS (
 
     SELECT
         {{ parent_hashkey }},

--- a/macros/tables/fabric/ma_sat_v1.sql
+++ b/macros/tables/fabric/ma_sat_v1.sql
@@ -22,10 +22,9 @@
 {% set hashkey = datavault4dbt.escape_column_names(hashkey) %}
 {% set hashdiff = datavault4dbt.escape_column_names(hashdiff) %}
 
+WITH
 
 {{ datavault4dbt.prepend_generated_by() }}
-
-WITH
 
 {# Getting everything from the underlying v0 satellite. #}
 source_satellite AS (

--- a/macros/tables/fabric/nh_link.sql
+++ b/macros/tables/fabric/nh_link.sql
@@ -50,9 +50,9 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {%- if is_incremental() -%}
 {# Get all link hashkeys out of the existing link for later incremental logic. #}

--- a/macros/tables/fabric/nh_sat.sql
+++ b/macros/tables/fabric/nh_sat.sql
@@ -16,10 +16,9 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 
+WITH
 
 {{ datavault4dbt.prepend_generated_by() }}
-
-WITH
 
 {# Selecting all source data, that is newer than latest data in sat if incremental #}
 source_data AS (

--- a/macros/tables/fabric/pit.sql
+++ b/macros/tables/fabric/pit.sql
@@ -27,10 +27,9 @@
 {%- set ldts = datavault4dbt.escape_column_names(ldts) -%}
 {%- set ledts = datavault4dbt.escape_column_names(ledts) -%}
 
+WITH
 
 {{ datavault4dbt.prepend_generated_by() }}
-
-WITH
 
 {%- if is_incremental() %}
 

--- a/macros/tables/fabric/rec_track_sat.sql
+++ b/macros/tables/fabric/rec_track_sat.sql
@@ -30,10 +30,9 @@
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set src_stg = datavault4dbt.escape_column_names(src_stg) -%}
 
+WITH
 
 {{ datavault4dbt.prepend_generated_by() }}
-
-WITH
 
 {% if is_incremental() %}
 

--- a/macros/tables/fabric/ref_hub.sql
+++ b/macros/tables/fabric/ref_hub.sql
@@ -28,9 +28,9 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {% if is_incremental() -%}
 {# Get all target ref_keys out of the existing ref_table for later incremental logic. #}

--- a/macros/tables/fabric/ref_sat_v0.sql
+++ b/macros/tables/fabric/ref_sat_v0.sql
@@ -27,9 +27,9 @@
 {%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {# Selecting all source data, that is newer than latest data in ref_sat if incremental #}
 source_data AS (

--- a/macros/tables/fabric/ref_sat_v1.sql
+++ b/macros/tables/fabric/ref_sat_v1.sql
@@ -22,10 +22,9 @@
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
 
+WITH
 
 {{ datavault4dbt.prepend_generated_by() }}
-
-WITH
 
 {# Calculate ledts based on the ldts of the earlier record. #}
 end_dated_source AS (

--- a/macros/tables/fabric/ref_table.sql
+++ b/macros/tables/fabric/ref_table.sql
@@ -39,10 +39,9 @@
 {%- set sdts_alias = datavault4dbt.escape_column_names(sdts_alias) -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
+WITH 
 
 {{ datavault4dbt.prepend_generated_by() }}
-
-WITH 
 
 dates AS (
 

--- a/macros/tables/fabric/sat_v0.sql
+++ b/macros/tables/fabric/sat_v0.sql
@@ -23,9 +23,9 @@
 {% set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) %}
 {% set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) %}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {# Selecting all source data, that is newer than latest data in sat if incremental #}
 source_data AS (

--- a/macros/tables/fabric/sat_v1.sql
+++ b/macros/tables/fabric/sat_v1.sql
@@ -20,9 +20,9 @@
 {% set hashkey = datavault4dbt.escape_column_names(hashkey) %}
 {% set hashdiff = datavault4dbt.escape_column_names(hashdiff) %}
 
-{{ datavault4dbt.prepend_generated_by() }}
-
 WITH
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 {# Calculate ledts based on the ldts of the earlier record. #}
 end_dated_source AS (


### PR DESCRIPTION
# Description

`prepend_generated_by()` moved after `WITH` to allow Data Preview for Microsoft Fabric for all front-end macros.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

