### PR TITLE
fix yaml_metadata_parser to not treat false values like none values

### DIFF
--- a/macros/internal/helpers/is_checks.sql
+++ b/macros/internal/helpers/is_checks.sql
@@ -81,3 +81,14 @@
     {%- endif -%}
 
 {%- endmacro -%}
+
+
+{% macro is_something_or_false(obj) %}
+
+    {%- if obj is not none and obj is defined -%}
+        {%- do return(true) -%}
+    {%- else -%}
+        {%- do return(false) -%}
+    {%- endif -%}
+    
+{% endmacro %}

--- a/macros/internal/metadata_processing/yaml_metadata_parser.sql
+++ b/macros/internal/metadata_processing/yaml_metadata_parser.sql
@@ -4,10 +4,10 @@
         {%- set metadata_dict = fromyaml(yaml_metadata) -%}
         {% if name in metadata_dict.keys() %}
             {% set return_value = metadata_dict.get(name) %}
-            {% if datavault4dbt.is_something(parameter)%}
+            {% if datavault4dbt.is_something_or_false(parameter)%}
                 {{ log("[" ~ this ~ "] Parameter '" ~ name ~ "' defined both in yaml-metadata and separately. Value from yaml-metadata will be used, and separate parameter is ignored.", info=False) }}
             {% endif %}
-        {% elif datavault4dbt.is_something(parameter) %}
+        {% elif datavault4dbt.is_something_or_false(parameter) %}
             {% set return_value = parameter %}
             {{ log("[" ~ this ~ "] yaml-metadata given, but parameter '" ~ name ~ "' not defined in there. Applying '" ~ parameter ~ "' which is either a parameter passed separately or the default value.", info=False) }}
         {% elif required %}
@@ -15,7 +15,7 @@
         {% else %}
             {% set return_value = None %}
         {% endif %}
-    {% elif datavault4dbt.is_something(parameter) %}
+    {% elif datavault4dbt.is_something_or_false(parameter) %}
         {% set return_value = parameter %}
     {% elif required %}
         {{ exceptions.raise_compiler_error("[" ~ this ~ "] Error: Required parameter '" ~ name ~ "' not defined. Define it either directly, or inside yaml-metadata. \n Description of parameter '" ~ name ~ "': \n" ~ documentation ) }}
@@ -25,4 +25,15 @@
 
     {{ return(return_value) }}
 
+{% endmacro %}
+
+
+{% macro is_something_or_false(obj) %}
+
+    {%- if obj is not none and obj is defined -%}
+        {%- do return(true) -%}
+    {%- else -%}
+        {%- do return(false) -%}
+    {%- endif -%}
+    
 {% endmacro %}

--- a/macros/internal/metadata_processing/yaml_metadata_parser.sql
+++ b/macros/internal/metadata_processing/yaml_metadata_parser.sql
@@ -26,14 +26,3 @@
     {{ return(return_value) }}
 
 {% endmacro %}
-
-
-{% macro is_something_or_false(obj) %}
-
-    {%- if obj is not none and obj is defined -%}
-        {%- do return(true) -%}
-    {%- else -%}
-        {%- do return(false) -%}
-    {%- endif -%}
-    
-{% endmacro %}


### PR DESCRIPTION
# Description

If a top-level macro parameter was set to `false` it was falsely treated the same way as if no value was set.
To accommodate this the check in the `yaml_metadata_parser` was modified.

Fixes #321 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

