### PR TITLE
fix snowflake md5 binary hash default values

### DIFF
--- a/macros/supporting/hash_default_values.sql
+++ b/macros/supporting/hash_default_values.sql
@@ -48,8 +48,8 @@
         {%- set error_key = '!ffffffffffffffffffffffffffffffff' -%}
     {%- elif (hash_function == 'MD5' or hash_function == 'MD5_BINARY') and hash_datatype == 'BINARY' -%}
         {%- set hash_alg = 'MD5_BINARY' -%}
-        {%- set unknown_key = "TO_BINARY('0000000000000000000000000000000000000000')" -%}
-        {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffffffffffff')" -%}
+        {%- set unknown_key = "TO_BINARY('00000000000000000000000000000000')" -%}
+        {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffff')" -%}
     {%- elif hash_function == 'SHA1' or hash_function == 'SHA1_HEX' or hash_function == 'SHA' -%} 
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
             {%- set hash_alg = 'SHA1' -%}


### PR DESCRIPTION
# Description

The md5_binary hash default value contained 40 instead of 32 characters

