### PR TITLE
Add databricks column case sensitivity setting via set_casing variable

### DIFF
--- a/macros/internal/metadata_processing/escape_column_names.sql
+++ b/macros/internal/metadata_processing/escape_column_names.sql
@@ -192,7 +192,7 @@
     {%- set escape_char_left  = var('escape_char_left',  "") -%}
     {%- set escape_char_right = var('escape_char_right', "") -%}
 
-    {%- set escaped_column_name = escape_char_left ~ column | upper | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
+    {%- set escaped_column_name = escape_char_left ~ column | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
 
     {% set set_casing = var('datavault4dbt.set_casing', none) %}
     {% if set_casing|lower in ['upper', 'uppercase'] %}

--- a/macros/internal/metadata_processing/escape_column_names.sql
+++ b/macros/internal/metadata_processing/escape_column_names.sql
@@ -194,6 +194,13 @@
 
     {%- set escaped_column_name = escape_char_left ~ column | upper | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
 
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
+        {%- set escaped_column_name = escaped_column_name | upper -%}
+    {% elif set_casing|lower in ['lower', 'lowercase'] %}
+        {%- set escaped_column_name = escaped_column_name | lower -%}
+    {% endif %}
+
     {%- do return(escaped_column_name) -%}
 
 {%- endmacro -%}

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -69,6 +69,42 @@
 {%- endmacro -%}
 
 
+{%- macro databricks__process_columns_to_select(columns_list, exclude_columns_list) -%}
+
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
+        {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
+        {% set columns_list = columns_list | map('upper') | list %}
+    {% elif set_casing|lower in ['lower', 'lowercase'] %}
+        {% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
+        {% set columns_list = columns_list | map('lower') | list %}
+    {% endif %}
+
+    {% set columns_to_select = [] %}
+
+    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
+
+        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+
+    {%- endif -%}
+
+    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+        {%- for col in columns_list -%}
+
+            {%- if col not in exclude_columns_list -%}
+                {%- do columns_to_select.append(col) -%}
+            {%- endif -%}
+
+        {%- endfor -%}
+    {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
+        {% set columns_to_select = columns_list %}
+    {%- endif -%}
+
+    {%- do return(columns_to_select) -%}
+    
+{%- endmacro -%}
+
+
 {%- macro synapse__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
     {{ return (datavault4dbt.default__process_columns_to_select(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}

--- a/macros/tables/databricks/hub.sql
+++ b/macros/tables/databricks/hub.sql
@@ -25,6 +25,13 @@
 {{ log('source_models: '~source_models, false) }}
 
 {%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
+
+{%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
+{%- set business_keys = datavault4dbt.escape_column_names(business_keys) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/databricks/link.sql
+++ b/macros/tables/databricks/link.sql
@@ -29,6 +29,13 @@
 
 {%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
 
+{%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
+{%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
+{%- set foreign_hashkeys = datavault4dbt.escape_column_names(foreign_hashkeys) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH

--- a/macros/tables/databricks/ma_sat_v0.sql
+++ b/macros/tables/databricks/ma_sat_v0.sql
@@ -14,9 +14,19 @@
 {%- endif -%}
 
 {%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_ma_key, src_payload]) -%}
+{%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
 
 {%- set source_relation = ref(source_model) -%}
 
+{%- set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) -%}
+{%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
+{%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
+{%- set src_ma_key = datavault4dbt.escape_column_names(src_ma_key) -%}
+{%- set src_payload = datavault4dbt.escape_column_names(src_payload) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+ 
+{{ datavault4dbt.prepend_generated_by() }}
 
 WITH
 

--- a/macros/tables/databricks/ma_sat_v1.sql
+++ b/macros/tables/databricks/ma_sat_v1.sql
@@ -4,6 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(sat_v0) -%}
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}

--- a/macros/tables/databricks/ma_sat_v1.sql
+++ b/macros/tables/databricks/ma_sat_v1.sql
@@ -10,9 +10,16 @@
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
 {%- set exclude = datavault4dbt.expand_column_list(columns=[hashkey, hashdiff, ma_attribute, src_ldts, src_rsrc]) -%}
 {%- set ma_attributes = datavault4dbt.expand_column_list(columns=[ma_attribute]) -%}
-
+{%- set ma_attributes = datavault4dbt.escape_column_names(ma_attributes) -%}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
+{%- set source_columns_to_select = datavault4dbt.escape_column_names(source_columns_to_select) -%}
+
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+{%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
+{%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
+{%- set hashdiff = datavault4dbt.escape_column_names(hashdiff) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/databricks/nh_link.sql
+++ b/macros/tables/databricks/nh_link.sql
@@ -42,6 +42,13 @@
 {%- endif -%}
 {%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
 
+{%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
+{%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
+{%- set foreign_hashkeys = datavault4dbt.escape_column_names(foreign_hashkeys) -%}
+{%- set payload = datavault4dbt.escape_column_names(payload) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH
@@ -163,14 +170,14 @@ WITH
 src_new_{{ source_number }} AS (
 
     SELECT
-            {{ link_hk }} AS {{ link_hashkey }},
+            {{ datavault4dbt.escape_column_names(link_hk) }} AS {{ link_hashkey }},
             {% for fk in source_model['fk_columns'] -%}
-            {{ fk }},
+            {{ datavault4dbt.escape_column_names(fk) }},
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
 
-        {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
+        {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_model['payload'])) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
     {# If the model is incremental and all sources has rsrc_static defined and valid and the source was already included before in the target transactional link #}
@@ -210,7 +217,7 @@ source_new_union AS (
     SELECT
         {{ link_hashkey }},
         {% for fk in source_model['fk_columns']|list %}
-            {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
+            {{ datavault4dbt.escape_column_names(fk) }} AS {{ datavault4dbt.escape_column_names(foreign_hashkeys[loop.index - 1]) }},
         {% endfor -%}
 
         {{ src_ldts }},

--- a/macros/tables/databricks/nh_sat.sql
+++ b/macros/tables/databricks/nh_sat.sql
@@ -8,6 +8,12 @@
 
 {%- set source_relation = ref(source_model) -%}
 
+{%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
+{%- set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) -%}
+{%- set src_payload = datavault4dbt.escape_column_names(src_payload) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH

--- a/macros/tables/databricks/pit.sql
+++ b/macros/tables/databricks/pit.sql
@@ -14,6 +14,7 @@
 {%- endif -%}
 
 {%- set rsrc = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
+{%- set rsrc = datavault4dbt.escape_column_names(rsrc) -%}
 
 {%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
@@ -24,6 +25,11 @@
 {%- else -%}
     {%- set hashed_cols = [hashkey_string, datavault4dbt.prefix([sdts], 'snap')] -%}
 {%- endif -%}
+
+{%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
+{%- set sdts = datavault4dbt.escape_column_names(sdts) -%}
+{%- set ldts = datavault4dbt.escape_column_names(ldts) -%}
+{%- set ledts = datavault4dbt.escape_column_names(ledts) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -46,23 +52,23 @@ pit_records AS (
     SELECT
         
         {% if datavault4dbt.is_something(pit_type) -%}
-            {{ datavault4dbt.as_constant(pit_type) }} as type,
+            {{ datavault4dbt.as_constant(pit_type) }} as {{ datavault4dbt.escape_column_names('type') }},
         {%- endif %}
         {% if datavault4dbt.is_something(custom_rsrc) -%}
         '{{ custom_rsrc }}' as {{ rsrc }},
         {%- endif %}
         {{ datavault4dbt.hash(columns=hashed_cols,
-                    alias=dimension_key,
+                    alias=datavault4dbt.escape_column_names(dimension_key),
                     is_hashdiff=false)   }} ,
         te.{{ hashkey }},
         snap.{{ sdts }},
         {% for satellite in sat_names %}
           {% if refer_to_ghost_records %}
-            COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS hk_{{ satellite }},
-            COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ ldts }}_{{ satellite }}
+            COALESCE({{ satellite }}.{{ hashkey }}, CAST({{ datavault4dbt.as_constant(column_str=unknown_key) }} as {{ hash_dtype }})) AS {{datavault4dbt.escape_column_names('hk_'~ satellite)}},
+            COALESCE({{ satellite }}.{{ ldts }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) AS {{ datavault4dbt.escape_column_names(ldts~'_'~satellite)}}
           {% else %}
-            {{ satellite }}.{{ hashkey }} AS hk_{{ satellite }},
-            {{ satellite }}.{{ ldts }} AS {{ ldts }}_{{ satellite }}
+            {{ satellite }}.{{ hashkey }} AS {{datavault4dbt.escape_column_names('hk_'~ satellite)}},
+            {{ satellite }}.{{ ldts }} AS {{ datavault4dbt.escape_column_names(ldts~'_'~satellite)}}
           {% endif %}
         {{- "," if not loop.last }}
         {%- endfor %}

--- a/macros/tables/databricks/rec_track_sat.sql
+++ b/macros/tables/databricks/rec_track_sat.sql
@@ -25,6 +25,11 @@
 
 {%- set final_columns_to_select = [tracked_hashkey] + [src_ldts] + [src_rsrc] + [src_stg] -%}
 
+{%- set tracked_hashkey = datavault4dbt.escape_column_names(tracked_hashkey) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+{%- set src_stg = datavault4dbt.escape_column_names(src_stg) -%}
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH
@@ -124,7 +129,7 @@ WITH
 {%- for source_model in source_models %}
 
     {%- set source_number = source_model.id | string -%}
-    {%- set hk_column = source_model['hk_column'] -%}
+    {%- set hk_column = datavault4dbt.escape_column_names(source_model['hk_column']) -%}
     {%- if ns.has_rsrc_static_defined -%}
         {%- set rsrc_statics = ns.source_models_rsrc_dict[source_number|string] -%}
 
@@ -209,7 +214,7 @@ source_new_union AS (
 records_to_insert AS (
 
     SELECT
-    {{ datavault4dbt.print_list(final_columns_to_select) }}
+    {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(final_columns_to_select)) }}
     FROM {{ ns.last_cte }}
     WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }} 
     AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}

--- a/macros/tables/databricks/ref_hub.sql
+++ b/macros/tables/databricks/ref_hub.sql
@@ -22,6 +22,11 @@
 
 {%- set final_columns_to_select = ref_keys + [src_ldts] + [src_rsrc] -%}
 
+{%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
+{%- set ref_keys = datavault4dbt.escape_column_names(ref_keys) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH
@@ -135,7 +140,7 @@ WITH
 
         SELECT
             {% for ref_key in source_model['ref_keys'] -%}
-            {{ ref_key}},
+            {{ datavault4dbt.escape_column_names(ref_key)}},
             {% endfor -%}
 
             {{ src_ldts }},
@@ -167,7 +172,7 @@ source_new_union AS (
 
     SELECT
         {% for ref_key in source_model['ref_keys'] -%}
-            {{ ref_key }} AS {{ ref_keys[loop.index - 1] }},
+            {{ datavault4dbt.escape_column_names(ref_key) }} AS {{ datavault4dbt.escape_column_names(ref_keys[loop.index - 1]) }},
         {% endfor -%}
 
         {{ src_ldts }},
@@ -202,7 +207,7 @@ earliest_ref_key_over_all_sources AS (
 records_to_insert AS (
     {#- Select everything from the previous CTE, if incremental filter for hashkeys that are not already in the hub. #}
     SELECT
-        {{ datavault4dbt.print_list(final_columns_to_select) }}
+        {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(final_columns_to_select)) }}
     FROM {{ ns.last_cte }}
 
     {%- if is_incremental() %}

--- a/macros/tables/databricks/ref_sat_v0.sql
+++ b/macros/tables/databricks/ref_sat_v0.sql
@@ -5,6 +5,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
+{%- set parent_ref_keys = datavault4dbt.escape_column_names(parent_ref_keys) -%}
 
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
@@ -19,6 +20,13 @@
 {%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_payload]) -%}
 
 {%- set source_relation = ref(source_model) -%}
+
+{%- set ref_key = datavault4dbt.escape_column_names(ref_key) -%}
+{%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
+{%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
+{%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/databricks/ref_sat_v1.sql
+++ b/macros/tables/databricks/ref_sat_v1.sql
@@ -15,6 +15,13 @@
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
+{%- set source_columns_to_select = datavault4dbt.escape_column_names(source_columns_to_select) -%}
+{%- set ref_keys = datavault4dbt.escape_column_names(ref_keys) -%}
+{%- set hashdiff = datavault4dbt.escape_column_names(hashdiff) -%}
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+{%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH

--- a/macros/tables/databricks/ref_sat_v1.sql
+++ b/macros/tables/databricks/ref_sat_v1.sql
@@ -4,6 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 

--- a/macros/tables/databricks/ref_table.sql
+++ b/macros/tables/databricks/ref_table.sql
@@ -34,6 +34,12 @@
     {%- set ref_satellites_dict = ref_satellites -%}
 {%- endif -%}
 
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
+{%- set sdts_alias = datavault4dbt.escape_column_names(sdts_alias) -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
+
+{{ datavault4dbt.prepend_generated_by() }}
 
 WITH 
 
@@ -88,9 +94,9 @@ dates AS (
 ref_table AS (
 
     SELECT
-    {{ datavault4dbt.print_list(list_to_print=ref_key_cols, indent=2, src_alias='h') }},
-        ld.{{ date_column }},
-        h.{{ src_rsrc }},
+    {{ datavault4dbt.print_list(list_to_print=datavault4dbt.escape_column_names(ref_key_cols), indent=2, src_alias='h') }},
+        ld.{{ datavault4dbt.escape_column_names(date_column) }},
+        h.{{ datavault4dbt.escape_column_names(src_rsrc) }},
 
     {%- for satellite in ref_satellites_dict.keys() %}
 
@@ -110,7 +116,8 @@ ref_table AS (
         {%- endif -%}
 
     {%- set sat_columns = datavault4dbt.process_columns_to_select(sat_columns_pre, sat_columns_to_exclude) -%}
-    
+    {%- set sat_columns = datavault4dbt.escape_column_names(sat_columns) -%}
+
     {{- log('sat_columns: '~ sat_columns, false) -}}
 
     {{ datavault4dbt.print_list(list_to_print=sat_columns, indent=2, src_alias=sat_alias) }}
@@ -129,7 +136,7 @@ ref_table AS (
         {%- set sat_alias = 's_' + loop.index|string -%}
 
     LEFT JOIN {{ ref(satellite) }} {{ sat_alias }}
-        ON {{ datavault4dbt.multikey(columns=ref_key_cols, prefix=['h', sat_alias], condition='=') }}
+        ON {{ datavault4dbt.multikey(columns=datavault4dbt.escape_column_names(ref_key_cols), prefix=['h', sat_alias], condition='=') }}
         AND  ld.{{ date_column }} BETWEEN {{ sat_alias }}.{{ src_ldts }} AND {{ sat_alias }}.{{ ledts_alias }}
     
     {% endfor %}

--- a/macros/tables/databricks/sat_v0.sql
+++ b/macros/tables/databricks/sat_v0.sql
@@ -18,6 +18,11 @@
 
 {%- set source_relation = ref(source_model) -%}
 
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+{%- set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) -%}
+{%- set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) -%}
+
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH

--- a/macros/tables/databricks/sat_v1.sql
+++ b/macros/tables/databricks/sat_v1.sql
@@ -4,6 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(sat_v0) -%}
 

--- a/macros/tables/databricks/sat_v1.sql
+++ b/macros/tables/databricks/sat_v1.sql
@@ -12,6 +12,13 @@
 {%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
+{%- set source_columns_to_select = datavault4dbt.escape_column_names(source_columns_to_select) -%}
+
+{%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+{%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+{%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
+{%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
+{%- set hashdiff = datavault4dbt.escape_column_names(hashdiff) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/fabric/sat_v1.sql
+++ b/macros/tables/fabric/sat_v1.sql
@@ -3,7 +3,8 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'is_current') -%}
+{%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
+{%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
 
 {%- set source_relation = ref(sat_v0) -%}
 


### PR DESCRIPTION
# Description

- Adds Databricks support for upper & lower case column names via the `datavault4dbt.set_casing` variable. 
Replicates the existing implementation that was recently implemented for Fabric providers

- Includes `is_current` set_casing support for the bug mentioned in #315 
- Includes `is_current` set_casing support for sat_v1 object for the Fabric provider to match case settings for existing Fabric ma_sat_v1 & ref_sat_v1 objects.

Fixes #315

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Thanks to @diveyseek for the groundwork!