### PR TITLE
add 'join_type' parameter in staging

### DIFF
--- a/macros/staging/bigquery/stage.sql
+++ b/macros/staging/bigquery/stage.sql
@@ -335,7 +335,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/bigquery/stage.sql
+++ b/macros/staging/bigquery/stage.sql
@@ -334,9 +334,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/databricks/stage.sql
+++ b/macros/staging/databricks/stage.sql
@@ -12,7 +12,7 @@
                 multi_active_config,
                 enable_ghost_records) -%}
 
-{% if (source_model is none) and execute %}
+    {% if (source_model is none) and execute %}
 
     {%- set error_message -%}
     Staging error: Missing source_model configuration. A source model name must be provided.
@@ -28,10 +28,10 @@
     {{- exceptions.raise_compiler_error(error_message) -}}
 {%- endif -%}
 
-{{ log('source_model: ' ~ source_model, false )}}
+    {{ log('source_model: ' ~ source_model, false ) }}
 
-{#- Check for source format or ref format and create relation object from source_model -#}
-{% if source_model is mapping and source_model is not none -%}
+    {#- Check for source format or ref format and create relation object from source_model -#}
+    {% if source_model is mapping and source_model is not none -%}
 
     {%- set source_name = source_model | first -%}
     {%- set source_table_name = source_model[source_name] -%}
@@ -49,30 +49,30 @@
     {%- set all_source_columns = [] -%}
 {%- endif -%}
 
-{{ log('source_relation: ' ~ source_relation, false) }}
+    {{ log('source_relation: ' ~ source_relation, false) }}
 
-{# Setting the column name for load date timestamp and record source to the alias coming from the attributes #}
-{%- set ldts_alias = var('datavault4dbt.ldts_alias', 'ldts') -%}
-{%- set rsrc_alias = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
-{%- set copy_input_columns = var('datavault4dbt.copy_rsrc_ldts_input_columns', false) -%}
-{%- set load_datetime_col_name = ldts_alias -%}
-{%- set record_source_col_name = rsrc_alias -%}
+    {# Setting the column name for load date timestamp and record source to the alias coming from the attributes #}
+    {%- set ldts_alias = var('datavault4dbt.ldts_alias', 'ldts') -%}
+    {%- set rsrc_alias = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
+    {%- set copy_input_columns = var('datavault4dbt.copy_rsrc_ldts_input_columns', false) -%}
+    {%- set load_datetime_col_name = ldts_alias -%}
+    {%- set record_source_col_name = rsrc_alias -%}
 
-{%- set ldts_rsrc_input_column_names = [] -%}
-{%- if datavault4dbt.is_attribute(ldts) -%}
+    {%- set ldts_rsrc_input_column_names = [] -%}
+    {%- if datavault4dbt.is_attribute(ldts) -%}
   {%- if not copy_input_columns -%}
-      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts]  -%}
+      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts] -%}
   {%- else -%}
     
     {%- if ldts|lower == ldts_alias|lower -%}
-      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts]  -%}
+      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts] -%}
     {%- endif -%}
 
   {%- endif %}
 
 {%- endif -%}
 
-{%- if datavault4dbt.is_attribute(rsrc) -%}
+    {%- if datavault4dbt.is_attribute(rsrc) -%}
 
   {%- if not copy_input_columns -%}
     {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [rsrc] -%}
@@ -86,27 +86,27 @@
 
 {%- endif %}
 
-{%- if datavault4dbt.is_something(sequence) -%}
+    {%- if datavault4dbt.is_something(sequence) -%}
   {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [sequence] -%}
 {%- endif -%}
 
-{%- set ldts = datavault4dbt.as_constant(ldts) -%}
-{%- set rsrc = datavault4dbt.as_constant(rsrc) -%}
+    {%- set ldts = datavault4dbt.as_constant(ldts) -%}
+    {%- set rsrc = datavault4dbt.as_constant(rsrc) -%}
 
-{# Getting the column names for all additional columns #}
-{%- set derived_column_names = datavault4dbt.extract_column_names(derived_columns) -%}
-{%- set hashed_column_names = datavault4dbt.extract_column_names(hashed_columns) -%}
-{%- set prejoined_column_names = datavault4dbt.extract_prejoin_column_names(prejoined_columns) -%}
-{%- set missing_column_names = datavault4dbt.extract_column_names(missing_columns) -%}
-{%- set exclude_column_names = derived_column_names + hashed_column_names + prejoined_column_names + missing_column_names + ldts_rsrc_input_column_names %}
-{%- set source_and_derived_column_names = (all_source_columns + derived_column_names) | unique | list -%}
-{%- set all_columns = adapter.get_columns_in_relation( source_relation ) -%}
-{%- set columns_without_excluded_columns = [] -%}
-{%- set final_columns_to_select = [] -%}
+    {# Getting the column names for all additional columns #}
+    {%- set derived_column_names = datavault4dbt.extract_column_names(derived_columns) -%}
+    {%- set hashed_column_names = datavault4dbt.extract_column_names(hashed_columns) -%}
+    {%- set prejoined_column_names = datavault4dbt.extract_prejoin_column_names(prejoined_columns) -%}
+    {%- set missing_column_names = datavault4dbt.extract_column_names(missing_columns) -%}
+    {%- set exclude_column_names = derived_column_names + hashed_column_names + prejoined_column_names + missing_column_names + ldts_rsrc_input_column_names %}
+    {%- set source_and_derived_column_names = (all_source_columns + derived_column_names) | unique | list -%}
+    {%- set all_columns = adapter.get_columns_in_relation( source_relation ) -%}
+    {%- set columns_without_excluded_columns = [] -%}
+    {%- set final_columns_to_select = [] -%}
 
-{%- set derived_input_columns = datavault4dbt.extract_input_columns(derived_columns) -%}
+    {%- set derived_input_columns = datavault4dbt.extract_input_columns(derived_columns) -%}
 
-{%- if include_source_columns -%}
+    {%- if include_source_columns -%}
   {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_source_columns, exclude_column_names) | list -%}
   {%- set source_columns_to_select = (source_columns_to_select + derived_input_columns) | unique | list -%}
 
@@ -150,42 +150,42 @@
 
   {%- set source_columns_to_select = only_include_from_source -%}
 
-{%- endif-%}
+{%- endif -%}
 
-{%- set final_columns_to_select = final_columns_to_select + source_columns_to_select -%}
-{%- set derived_columns_to_select = datavault4dbt.process_columns_to_select(source_and_derived_column_names, hashed_column_names) | unique | list -%}
+    {%- set final_columns_to_select = final_columns_to_select + source_columns_to_select -%}
+    {%- set derived_columns_to_select = datavault4dbt.process_columns_to_select(source_and_derived_column_names, hashed_column_names) | unique | list -%}
 
-{%- if datavault4dbt.is_something(derived_columns) %}
+    {%- if datavault4dbt.is_something(derived_columns) %}
   {#- Getting Data types for derived columns with detection from source relation -#}
   {%- set derived_columns_with_datatypes = datavault4dbt.derived_columns_datatypes(derived_columns, source_relation) -%}
   {%- set derived_columns_with_datatypes_DICT = fromjson(derived_columns_with_datatypes) -%}
 {%- endif -%}
-{#- Select hashing algorithm -#}
+    {#- Select hashing algorithm -#}
 
-{#- Setting unknown and error keys with default values for the selected hash algorithm -#}
-{%- set hash = datavault4dbt.hash_method() -%}
-{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
-{%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
-{%- set hash_alg = hash_default_values['hash_alg'] -%}
-{%- set unknown_key = hash_default_values['unknown_key'] -%}
-{%- set error_key = hash_default_values['error_key'] -%}
+    {#- Setting unknown and error keys with default values for the selected hash algorithm -#}
+    {%- set hash = datavault4dbt.hash_method() -%}
+    {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
+    {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
+    {%- set hash_alg = hash_default_values['hash_alg'] -%}
+    {%- set unknown_key = hash_default_values['unknown_key'] -%}
+    {%- set error_key = hash_default_values['error_key'] -%}
 
-{# Select timestamp and format variables #}
-{%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
-{%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
-{%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+    {# Select timestamp and format variables #}
+    {%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
+    {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
+    {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Setting the error/unknown value for the record source  for the ghost records#}
-{% set error_value_rsrc = var('datavault4dbt.default_error_rsrc', 'ERROR') %}
-{% set unknown_value_rsrc = var('datavault4dbt.default_unknown_rsrc', 'SYSTEM') %}
+    {# Setting the error/unknown value for the record source  for the ghost records#}
+    {% set error_value_rsrc = var('datavault4dbt.default_error_rsrc', 'ERROR') %}
+    {% set unknown_value_rsrc = var('datavault4dbt.default_unknown_rsrc', 'SYSTEM') %}
 
-{# Setting the rsrc default datatype and length #}
-{% set rsrc_default_dtype = datavault4dbt.string_default_dtype(type='rsrc') %}
+    {# Setting the rsrc default datatype and length #}
+    {% set rsrc_default_dtype = datavault4dbt.string_default_dtype(type='rsrc') %}
 
-{# Setting the ldts default datatype #}
-{% set ldts_default_dtype = datavault4dbt.timestamp_default_dtype() %}
+    {# Setting the ldts default datatype #}
+    {% set ldts_default_dtype = datavault4dbt.timestamp_default_dtype() %}
 
-{{ datavault4dbt.prepend_generated_by() }}
+    {{ datavault4dbt.prepend_generated_by() }}
 
 WITH
 
@@ -197,19 +197,19 @@ source_data AS (
 
   FROM {{ source_relation }}
 
-  {% if is_incremental() %}
-  WHERE {{ ldts }} > (SELECT max({{ load_datetime_col_name}}) 
+    {% if is_incremental() %}
+  WHERE {{ ldts }} > (SELECT max({{ load_datetime_col_name }}) 
                       FROM {{ this }} 
-                      WHERE {{ load_datetime_col_name}} != {{ datavault4dbt.string_to_timestamp(timestamp_format , end_of_all_times) }} )
+                      WHERE {{ load_datetime_col_name }} != {{ datavault4dbt.string_to_timestamp(timestamp_format , end_of_all_times) }} )
   {%- endif -%}
 
-  {% set last_cte = "source_data" -%}
+    {% set last_cte = "source_data" -%}
 ),
 
 
 {% set alias_columns = [load_datetime_col_name, record_source_col_name] %}
 
-{# Selecting all columns from the source data, renaming load date and record source to global aliases #}
+    {# Selecting all columns from the source data, renaming load date and record source to global aliases #}
 ldts_rsrc_data AS (
 
   SELECT
@@ -220,25 +220,27 @@ ldts_rsrc_data AS (
       {%- set alias_columns = alias_columns + ['edwSequence'] -%}
     {% endif -%}
 
-    {%- if source_columns_to_select is not none and source_columns_to_select | length > 0 %},
+    {%- if source_columns_to_select is not none and source_columns_to_select | length > 0 %}
+        ,
       {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) }}
+    
     {% endif -%}
-    {{"\n"}}
+    {{ "\n" }}
   FROM {{ last_cte }}
 
-  {%- set last_cte = "ldts_rsrc_data" -%}
-  {%- set final_columns_to_select = alias_columns + final_columns_to_select  %}
+    {%- set last_cte = "ldts_rsrc_data" -%}
+    {%- set final_columns_to_select = alias_columns + final_columns_to_select %}
 
-  {%- set columns_without_excluded_columns_tmp = [] -%}
-  {%- for column in columns_without_excluded_columns -%}
+    {%- set columns_without_excluded_columns_tmp = [] -%}
+    {%- for column in columns_without_excluded_columns -%}
     {%- if column.name | lower not in derived_column_names | map('lower') -%}
       {%- do columns_without_excluded_columns_tmp.append(column) -%}
     {%- endif -%}
   {%- endfor -%}
-  {%- set columns_without_excluded_columns = columns_without_excluded_columns_tmp |list -%}
-),
+    {%- set columns_without_excluded_columns = columns_without_excluded_columns_tmp |list -%}
+    ),
 
-{%- if datavault4dbt.is_something(missing_columns) %}
+    {%- if datavault4dbt.is_something(missing_columns) %}
 
 {# Filling missing columns with NULL values for schema changes #}
 missing_columns AS (
@@ -260,7 +262,7 @@ missing_columns AS (
 {%- endif -%}
 
 
-{%- if datavault4dbt.is_something(prejoined_columns) %}
+    {%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
 
@@ -274,7 +276,7 @@ prejoined_columns AS (
     {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
     {# If extract_columns and/or aliases are passed as string convert them to a list so they can be used as iterators later #}
-    {%- if not datavault4dbt.is_list(prejoin['extract_columns'])-%}
+    {%- if not datavault4dbt.is_list(prejoin['extract_columns']) -%}
       {%- do prejoin.update({'extract_columns': [prejoin['extract_columns']]}) -%}
     {%- endif -%}
     {%- if not datavault4dbt.is_list(prejoin['aliases']) and datavault4dbt.is_something(prejoin['aliases']) -%}
@@ -335,9 +337,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 
@@ -347,7 +354,7 @@ prejoined_columns AS (
 {%- endif -%}
 
 
-{%- if datavault4dbt.is_something(derived_columns) %}
+    {%- if datavault4dbt.is_something(derived_columns) %}
 {# Adding derived columns to the selection #}
 derived_columns AS (
 
@@ -366,7 +373,8 @@ derived_columns AS (
 ),
 {%- endif -%}
 
-{%- if datavault4dbt.is_something(hashed_columns) and hashed_columns is mapping %}
+    {%- if datavault4dbt.is_something(hashed_columns) and hashed_columns is mapping %}
+        
 {# Generating Hashed Columns (hashkeys and hashdiffs for Hubs/Links/Satellites) #}
 {% if datavault4dbt.is_something(multi_active_config) %}
 
@@ -459,9 +467,10 @@ hashed_columns AS (
 ),
 
 {%- endif -%}
-{%- endif -%}
 
-{% if enable_ghost_records and not is_incremental() %}
+    {%- endif -%}
+
+    {% if enable_ghost_records and not is_incremental() %}
 {# Creating Ghost Record for unknown case, based on datatype #}
 unknown_values AS (
 
@@ -525,7 +534,7 @@ unknown_values AS (
       {%- endfor -%}
 
     {%- endif -%}
-    {{-"\n"-}}
+    {{- "\n" -}}
 ),
 
 {# Creating Ghost Record for error case, based on datatype #}
@@ -602,11 +611,11 @@ ghost_records AS (
 ),
 {%- endif -%}
 
-{%- if not include_source_columns -%}
+    {%- if not include_source_columns -%}
   {% set final_columns_to_select = datavault4dbt.process_columns_to_select(columns_list=final_columns_to_select, exclude_columns_list=source_columns_to_select) %}
 {%- endif -%}
 
-{# Combining the two ghost records with the regular data #}
+    {# Combining the two ghost records with the regular data #}
 columns_to_select AS (
 
     SELECT
@@ -615,7 +624,7 @@ columns_to_select AS (
 
     FROM {{ last_cte }}
 
-  {%- if enable_ghost_records and not is_incremental() %}
+    {%- if enable_ghost_records and not is_incremental() %}
     UNION ALL
     
     SELECT

--- a/macros/staging/databricks/stage.sql
+++ b/macros/staging/databricks/stage.sql
@@ -336,7 +336,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/databricks/stage.sql
+++ b/macros/staging/databricks/stage.sql
@@ -12,7 +12,7 @@
                 multi_active_config,
                 enable_ghost_records) -%}
 
-    {% if (source_model is none) and execute %}
+{% if (source_model is none) and execute %}
 
     {%- set error_message -%}
     Staging error: Missing source_model configuration. A source model name must be provided.
@@ -28,10 +28,10 @@
     {{- exceptions.raise_compiler_error(error_message) -}}
 {%- endif -%}
 
-    {{ log('source_model: ' ~ source_model, false ) }}
+{{ log('source_model: ' ~ source_model, false )}}
 
-    {#- Check for source format or ref format and create relation object from source_model -#}
-    {% if source_model is mapping and source_model is not none -%}
+{#- Check for source format or ref format and create relation object from source_model -#}
+{% if source_model is mapping and source_model is not none -%}
 
     {%- set source_name = source_model | first -%}
     {%- set source_table_name = source_model[source_name] -%}
@@ -49,30 +49,30 @@
     {%- set all_source_columns = [] -%}
 {%- endif -%}
 
-    {{ log('source_relation: ' ~ source_relation, false) }}
+{{ log('source_relation: ' ~ source_relation, false) }}
 
-    {# Setting the column name for load date timestamp and record source to the alias coming from the attributes #}
-    {%- set ldts_alias = var('datavault4dbt.ldts_alias', 'ldts') -%}
-    {%- set rsrc_alias = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
-    {%- set copy_input_columns = var('datavault4dbt.copy_rsrc_ldts_input_columns', false) -%}
-    {%- set load_datetime_col_name = ldts_alias -%}
-    {%- set record_source_col_name = rsrc_alias -%}
+{# Setting the column name for load date timestamp and record source to the alias coming from the attributes #}
+{%- set ldts_alias = var('datavault4dbt.ldts_alias', 'ldts') -%}
+{%- set rsrc_alias = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
+{%- set copy_input_columns = var('datavault4dbt.copy_rsrc_ldts_input_columns', false) -%}
+{%- set load_datetime_col_name = ldts_alias -%}
+{%- set record_source_col_name = rsrc_alias -%}
 
-    {%- set ldts_rsrc_input_column_names = [] -%}
-    {%- if datavault4dbt.is_attribute(ldts) -%}
+{%- set ldts_rsrc_input_column_names = [] -%}
+{%- if datavault4dbt.is_attribute(ldts) -%}
   {%- if not copy_input_columns -%}
-      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts] -%}
+      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts]  -%}
   {%- else -%}
     
     {%- if ldts|lower == ldts_alias|lower -%}
-      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts] -%}
+      {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [ldts]  -%}
     {%- endif -%}
 
   {%- endif %}
 
 {%- endif -%}
 
-    {%- if datavault4dbt.is_attribute(rsrc) -%}
+{%- if datavault4dbt.is_attribute(rsrc) -%}
 
   {%- if not copy_input_columns -%}
     {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [rsrc] -%}
@@ -86,27 +86,27 @@
 
 {%- endif %}
 
-    {%- if datavault4dbt.is_something(sequence) -%}
+{%- if datavault4dbt.is_something(sequence) -%}
   {%- set ldts_rsrc_input_column_names = ldts_rsrc_input_column_names + [sequence] -%}
 {%- endif -%}
 
-    {%- set ldts = datavault4dbt.as_constant(ldts) -%}
-    {%- set rsrc = datavault4dbt.as_constant(rsrc) -%}
+{%- set ldts = datavault4dbt.as_constant(ldts) -%}
+{%- set rsrc = datavault4dbt.as_constant(rsrc) -%}
 
-    {# Getting the column names for all additional columns #}
-    {%- set derived_column_names = datavault4dbt.extract_column_names(derived_columns) -%}
-    {%- set hashed_column_names = datavault4dbt.extract_column_names(hashed_columns) -%}
-    {%- set prejoined_column_names = datavault4dbt.extract_prejoin_column_names(prejoined_columns) -%}
-    {%- set missing_column_names = datavault4dbt.extract_column_names(missing_columns) -%}
-    {%- set exclude_column_names = derived_column_names + hashed_column_names + prejoined_column_names + missing_column_names + ldts_rsrc_input_column_names %}
-    {%- set source_and_derived_column_names = (all_source_columns + derived_column_names) | unique | list -%}
-    {%- set all_columns = adapter.get_columns_in_relation( source_relation ) -%}
-    {%- set columns_without_excluded_columns = [] -%}
-    {%- set final_columns_to_select = [] -%}
+{# Getting the column names for all additional columns #}
+{%- set derived_column_names = datavault4dbt.extract_column_names(derived_columns) -%}
+{%- set hashed_column_names = datavault4dbt.extract_column_names(hashed_columns) -%}
+{%- set prejoined_column_names = datavault4dbt.extract_prejoin_column_names(prejoined_columns) -%}
+{%- set missing_column_names = datavault4dbt.extract_column_names(missing_columns) -%}
+{%- set exclude_column_names = derived_column_names + hashed_column_names + prejoined_column_names + missing_column_names + ldts_rsrc_input_column_names %}
+{%- set source_and_derived_column_names = (all_source_columns + derived_column_names) | unique | list -%}
+{%- set all_columns = adapter.get_columns_in_relation( source_relation ) -%}
+{%- set columns_without_excluded_columns = [] -%}
+{%- set final_columns_to_select = [] -%}
 
-    {%- set derived_input_columns = datavault4dbt.extract_input_columns(derived_columns) -%}
+{%- set derived_input_columns = datavault4dbt.extract_input_columns(derived_columns) -%}
 
-    {%- if include_source_columns -%}
+{%- if include_source_columns -%}
   {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_source_columns, exclude_column_names) | list -%}
   {%- set source_columns_to_select = (source_columns_to_select + derived_input_columns) | unique | list -%}
 
@@ -150,42 +150,42 @@
 
   {%- set source_columns_to_select = only_include_from_source -%}
 
-{%- endif -%}
+{%- endif-%}
 
-    {%- set final_columns_to_select = final_columns_to_select + source_columns_to_select -%}
-    {%- set derived_columns_to_select = datavault4dbt.process_columns_to_select(source_and_derived_column_names, hashed_column_names) | unique | list -%}
+{%- set final_columns_to_select = final_columns_to_select + source_columns_to_select -%}
+{%- set derived_columns_to_select = datavault4dbt.process_columns_to_select(source_and_derived_column_names, hashed_column_names) | unique | list -%}
 
-    {%- if datavault4dbt.is_something(derived_columns) %}
+{%- if datavault4dbt.is_something(derived_columns) %}
   {#- Getting Data types for derived columns with detection from source relation -#}
   {%- set derived_columns_with_datatypes = datavault4dbt.derived_columns_datatypes(derived_columns, source_relation) -%}
   {%- set derived_columns_with_datatypes_DICT = fromjson(derived_columns_with_datatypes) -%}
 {%- endif -%}
-    {#- Select hashing algorithm -#}
+{#- Select hashing algorithm -#}
 
-    {#- Setting unknown and error keys with default values for the selected hash algorithm -#}
-    {%- set hash = datavault4dbt.hash_method() -%}
-    {%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
-    {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
-    {%- set hash_alg = hash_default_values['hash_alg'] -%}
-    {%- set unknown_key = hash_default_values['unknown_key'] -%}
-    {%- set error_key = hash_default_values['error_key'] -%}
+{#- Setting unknown and error keys with default values for the selected hash algorithm -#}
+{%- set hash = datavault4dbt.hash_method() -%}
+{%- set hash_dtype = var('datavault4dbt.hash_datatype', 'STRING') -%}
+{%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=hash,hash_datatype=hash_dtype)) -%}
+{%- set hash_alg = hash_default_values['hash_alg'] -%}
+{%- set unknown_key = hash_default_values['unknown_key'] -%}
+{%- set error_key = hash_default_values['error_key'] -%}
 
-    {# Select timestamp and format variables #}
-    {%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
-    {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
-    {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+{# Select timestamp and format variables #}
+{%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
+{%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
+{%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-    {# Setting the error/unknown value for the record source  for the ghost records#}
-    {% set error_value_rsrc = var('datavault4dbt.default_error_rsrc', 'ERROR') %}
-    {% set unknown_value_rsrc = var('datavault4dbt.default_unknown_rsrc', 'SYSTEM') %}
+{# Setting the error/unknown value for the record source  for the ghost records#}
+{% set error_value_rsrc = var('datavault4dbt.default_error_rsrc', 'ERROR') %}
+{% set unknown_value_rsrc = var('datavault4dbt.default_unknown_rsrc', 'SYSTEM') %}
 
-    {# Setting the rsrc default datatype and length #}
-    {% set rsrc_default_dtype = datavault4dbt.string_default_dtype(type='rsrc') %}
+{# Setting the rsrc default datatype and length #}
+{% set rsrc_default_dtype = datavault4dbt.string_default_dtype(type='rsrc') %}
 
-    {# Setting the ldts default datatype #}
-    {% set ldts_default_dtype = datavault4dbt.timestamp_default_dtype() %}
+{# Setting the ldts default datatype #}
+{% set ldts_default_dtype = datavault4dbt.timestamp_default_dtype() %}
 
-    {{ datavault4dbt.prepend_generated_by() }}
+{{ datavault4dbt.prepend_generated_by() }}
 
 WITH
 
@@ -197,19 +197,19 @@ source_data AS (
 
   FROM {{ source_relation }}
 
-    {% if is_incremental() %}
-  WHERE {{ ldts }} > (SELECT max({{ load_datetime_col_name }}) 
+  {% if is_incremental() %}
+  WHERE {{ ldts }} > (SELECT max({{ load_datetime_col_name}}) 
                       FROM {{ this }} 
-                      WHERE {{ load_datetime_col_name }} != {{ datavault4dbt.string_to_timestamp(timestamp_format , end_of_all_times) }} )
+                      WHERE {{ load_datetime_col_name}} != {{ datavault4dbt.string_to_timestamp(timestamp_format , end_of_all_times) }} )
   {%- endif -%}
 
-    {% set last_cte = "source_data" -%}
+  {% set last_cte = "source_data" -%}
 ),
 
 
 {% set alias_columns = [load_datetime_col_name, record_source_col_name] %}
 
-    {# Selecting all columns from the source data, renaming load date and record source to global aliases #}
+{# Selecting all columns from the source data, renaming load date and record source to global aliases #}
 ldts_rsrc_data AS (
 
   SELECT
@@ -220,27 +220,25 @@ ldts_rsrc_data AS (
       {%- set alias_columns = alias_columns + ['edwSequence'] -%}
     {% endif -%}
 
-    {%- if source_columns_to_select is not none and source_columns_to_select | length > 0 %}
-        ,
+    {%- if source_columns_to_select is not none and source_columns_to_select | length > 0 %},
       {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) }}
-    
     {% endif -%}
-    {{ "\n" }}
+    {{"\n"}}
   FROM {{ last_cte }}
 
-    {%- set last_cte = "ldts_rsrc_data" -%}
-    {%- set final_columns_to_select = alias_columns + final_columns_to_select %}
+  {%- set last_cte = "ldts_rsrc_data" -%}
+  {%- set final_columns_to_select = alias_columns + final_columns_to_select  %}
 
-    {%- set columns_without_excluded_columns_tmp = [] -%}
-    {%- for column in columns_without_excluded_columns -%}
+  {%- set columns_without_excluded_columns_tmp = [] -%}
+  {%- for column in columns_without_excluded_columns -%}
     {%- if column.name | lower not in derived_column_names | map('lower') -%}
       {%- do columns_without_excluded_columns_tmp.append(column) -%}
     {%- endif -%}
   {%- endfor -%}
-    {%- set columns_without_excluded_columns = columns_without_excluded_columns_tmp |list -%}
-    ),
+  {%- set columns_without_excluded_columns = columns_without_excluded_columns_tmp |list -%}
+),
 
-    {%- if datavault4dbt.is_something(missing_columns) %}
+{%- if datavault4dbt.is_something(missing_columns) %}
 
 {# Filling missing columns with NULL values for schema changes #}
 missing_columns AS (
@@ -262,7 +260,7 @@ missing_columns AS (
 {%- endif -%}
 
 
-    {%- if datavault4dbt.is_something(prejoined_columns) %}
+{%- if datavault4dbt.is_something(prejoined_columns) %}
 {# Prejoining Business Keys of other source objects for Link purposes #}
 prejoined_columns AS (
 
@@ -276,7 +274,7 @@ prejoined_columns AS (
     {%- set prejoin_alias = 'pj_' + loop.index|string -%}
 
     {# If extract_columns and/or aliases are passed as string convert them to a list so they can be used as iterators later #}
-    {%- if not datavault4dbt.is_list(prejoin['extract_columns']) -%}
+    {%- if not datavault4dbt.is_list(prejoin['extract_columns'])-%}
       {%- do prejoin.update({'extract_columns': [prejoin['extract_columns']]}) -%}
     {%- endif -%}
     {%- if not datavault4dbt.is_list(prejoin['aliases']) and datavault4dbt.is_something(prejoin['aliases']) -%}
@@ -354,7 +352,7 @@ prejoined_columns AS (
 {%- endif -%}
 
 
-    {%- if datavault4dbt.is_something(derived_columns) %}
+{%- if datavault4dbt.is_something(derived_columns) %}
 {# Adding derived columns to the selection #}
 derived_columns AS (
 
@@ -373,8 +371,7 @@ derived_columns AS (
 ),
 {%- endif -%}
 
-    {%- if datavault4dbt.is_something(hashed_columns) and hashed_columns is mapping %}
-        
+{%- if datavault4dbt.is_something(hashed_columns) and hashed_columns is mapping %}
 {# Generating Hashed Columns (hashkeys and hashdiffs for Hubs/Links/Satellites) #}
 {% if datavault4dbt.is_something(multi_active_config) %}
 
@@ -467,10 +464,9 @@ hashed_columns AS (
 ),
 
 {%- endif -%}
+{%- endif -%}
 
-    {%- endif -%}
-
-    {% if enable_ghost_records and not is_incremental() %}
+{% if enable_ghost_records and not is_incremental() %}
 {# Creating Ghost Record for unknown case, based on datatype #}
 unknown_values AS (
 
@@ -534,7 +530,7 @@ unknown_values AS (
       {%- endfor -%}
 
     {%- endif -%}
-    {{- "\n" -}}
+    {{-"\n"-}}
 ),
 
 {# Creating Ghost Record for error case, based on datatype #}
@@ -611,11 +607,11 @@ ghost_records AS (
 ),
 {%- endif -%}
 
-    {%- if not include_source_columns -%}
+{%- if not include_source_columns -%}
   {% set final_columns_to_select = datavault4dbt.process_columns_to_select(columns_list=final_columns_to_select, exclude_columns_list=source_columns_to_select) %}
 {%- endif -%}
 
-    {# Combining the two ghost records with the regular data #}
+{# Combining the two ghost records with the regular data #}
 columns_to_select AS (
 
     SELECT
@@ -624,7 +620,7 @@ columns_to_select AS (
 
     FROM {{ last_cte }}
 
-    {%- if enable_ghost_records and not is_incremental() %}
+  {%- if enable_ghost_records and not is_incremental() %}
     UNION ALL
     
     SELECT

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -331,7 +331,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/exasol/stage.sql
+++ b/macros/staging/exasol/stage.sql
@@ -330,9 +330,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/fabric/stage.sql
+++ b/macros/staging/fabric/stage.sql
@@ -334,9 +334,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=datavault4dbt.escape_column_names(prejoin['this_column_name']), prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=datavault4dbt.escape_column_names(prejoin['ref_column_name'])) }}
   {%- endfor -%}
 

--- a/macros/staging/fabric/stage.sql
+++ b/macros/staging/fabric/stage.sql
@@ -335,7 +335,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/oracle/stage.sql
+++ b/macros/staging/oracle/stage.sql
@@ -342,7 +342,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/oracle/stage.sql
+++ b/macros/staging/oracle/stage.sql
@@ -341,9 +341,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/postgres/stage.sql
+++ b/macros/staging/postgres/stage.sql
@@ -335,9 +335,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/postgres/stage.sql
+++ b/macros/staging/postgres/stage.sql
@@ -336,7 +336,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/redshift/stage.sql
+++ b/macros/staging/redshift/stage.sql
@@ -335,9 +335,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/redshift/stage.sql
+++ b/macros/staging/redshift/stage.sql
@@ -336,7 +336,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -343,7 +343,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}

--- a/macros/staging/snowflake/stage.sql
+++ b/macros/staging/snowflake/stage.sql
@@ -342,9 +342,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -1,141 +1,141 @@
 {%- macro process_columns_to_select(columns_list=none, exclude_columns_list=none) -%}
 
-{{ return(adapter.dispatch('process_columns_to_select', 'datavault4dbt')(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
+    {{ return(adapter.dispatch('process_columns_to_select', 'datavault4dbt')(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
 
 {%- endmacro -%}
 
 
 {%- macro default__process_columns_to_select(columns_list, exclude_columns_list) -%}
-{% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
-{% set columns_list = columns_list | map('upper') | list %}
-{% set columns_to_select = [] %}
+    {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
+    {% set columns_list = columns_list | map('upper') | list %}
+    {% set columns_to_select = [] %}
 
-{% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list) %}
+    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
 
-{{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
 
-{%- endif -%}
+    {%- endif -%}
 
-{%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
-{%- for col in columns_list -%}
+    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+        {%- for col in columns_list -%}
 
-{%- if col not in exclude_columns_list -%}
+            {%- if col not in exclude_columns_list -%}
                 {%- do columns_to_select.append(col) -%}
             {%- endif -%}
 
         {%- endfor -%}
     {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
-{% set columns_to_select = columns_list %}
-{%- endif -%}
+        {% set columns_to_select = columns_list %}
+    {%- endif -%}
 
-{%- do return(columns_to_select) -%}
+    {%- do return(columns_to_select) -%}
 
 {%- endmacro -%}
 
     
 {%- macro fabric__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
-{% set set_casing = var('datavault4dbt.set_casing', none) %}
-{% if set_casing|lower in ['upper', 'uppercase'] %}
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
         {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
         {% set columns_list = columns_list | map('upper') | list %}
     {% elif set_casing|lower in ['lower', 'lowercase'] %}
-{% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
-{% set columns_list = columns_list | map('lower') | list %}
-{% endif %}
+        {% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
+        {% set columns_list = columns_list | map('lower') | list %}
+    {% endif %}
 
-{% set columns_to_select = [] %}
+    {% set columns_to_select = [] %}
 
-{% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list) %}
+    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
 
-{{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
 
-{%- endif -%}
+    {%- endif -%}
 
-{%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
-{%- for col in columns_list -%}
+    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+        {%- for col in columns_list -%}
 
-{%- if col not in exclude_columns_list -%}
+            {%- if col not in exclude_columns_list -%}
                 {%- do columns_to_select.append(col) -%}
             {%- endif -%}
 
         {%- endfor -%}
     {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
-{% set columns_to_select = columns_list %}
-{%- endif -%}
+        {% set columns_to_select = columns_list %}
+    {%- endif -%}
 
-{%- do return(columns_to_select) -%}
+    {%- do return(columns_to_select) -%}
 
 {%- endmacro -%}
 
 
 {%- macro databricks__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
-{% set set_casing = var('datavault4dbt.set_casing', none) %}
-{% if set_casing|lower in ['upper', 'uppercase'] %}
+    {% set set_casing = var('datavault4dbt.set_casing', none) %}
+    {% if set_casing|lower in ['upper', 'uppercase'] %}
         {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
         {% set columns_list = columns_list | map('upper') | list %}
     {% elif set_casing|lower in ['lower', 'lowercase'] %}
-{% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
-{% set columns_list = columns_list | map('lower') | list %}
-{% endif %}
+        {% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
+        {% set columns_list = columns_list | map('lower') | list %}
+    {% endif %}
 
-{% set columns_to_select = [] %}
+    {% set columns_to_select = [] %}
 
-{% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list) %}
+    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
 
-{{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
 
-{%- endif -%}
+    {%- endif -%}
 
-{%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
-{%- for col in columns_list -%}
+    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+        {%- for col in columns_list -%}
 
-{%- if col not in exclude_columns_list -%}
+            {%- if col not in exclude_columns_list -%}
                 {%- do columns_to_select.append(col) -%}
             {%- endif -%}
 
         {%- endfor -%}
     {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
-{% set columns_to_select = columns_list %}
-{%- endif -%}
+        {% set columns_to_select = columns_list %}
+    {%- endif -%}
 
-{%- do return(columns_to_select) -%}
+    {%- do return(columns_to_select) -%}
     
 {%- endmacro -%}
 
 
 {%- macro synapse__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
-{{ return (datavault4dbt.default__process_columns_to_select(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
+    {{ return (datavault4dbt.default__process_columns_to_select(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
 
 {%- endmacro -%}
 
 
 {%- macro extract_column_names(columns_dict=none) -%}
 
-{%- set extracted_column_names = [] -%}
+    {%- set extracted_column_names = [] -%}
 
-{%- if columns_dict is mapping -%}
-{%- for key, value in columns_dict.items() -%}
+    {%- if columns_dict is mapping -%}
+        {%- for key, value in columns_dict.items() -%}
             {%- do extracted_column_names.append(key) -%}
         {%- endfor -%}
 
         {%- do return(extracted_column_names) -%}
     {%- else -%}
-{%- do return([]) -%}
-{%- endif -%}
+        {%- do return([]) -%}
+    {%- endif -%}
 
 {%- endmacro -%}
 
 {%- macro extract_input_columns(columns_dict=none) -%}
 
-{%- set extracted_input_columns = [] -%}
+    {%- set extracted_input_columns = [] -%}
 
-{%- if columns_dict is mapping -%}
-{%- for key, value in columns_dict.items() -%}
-{%- if value is mapping and 'src_cols_required' in value.keys() -%}
-{% if datavault4dbt.is_list(value['src_cols_required']) %}
+    {%- if columns_dict is mapping -%}
+        {%- for key, value in columns_dict.items() -%}
+            {%- if value is mapping and 'src_cols_required' in value.keys() -%}
+                {% if datavault4dbt.is_list(value['src_cols_required']) %}
                     {% set extracted_input_columns = extracted_input_columns + value['src_cols_required'] %}
                 {% else %}
                     {%- do extracted_input_columns.append(value['src_cols_required']) -%}
@@ -150,9 +150,9 @@
         {%- endfor -%}
     
     {%- elif datavault4dbt.is_list(columns_dict) -%}
-{% for prejoin in columns_dict %}
-{%- if datavault4dbt.is_list(prejoin['this_column_name']) -%}
-{%- for column in prejoin['this_column_name'] -%}
+        {% for prejoin in columns_dict %}
+            {%- if datavault4dbt.is_list(prejoin['this_column_name'])-%}
+                {%- for column in prejoin['this_column_name'] -%}
                     {%- do extracted_input_columns.append(column) -%}
                 {%- endfor -%}
             {%- else -%}
@@ -160,24 +160,24 @@
             {%- endif -%}
         {% endfor %}
     {%- else -%}
-{%- do return([]) -%}
-{%- endif -%}
+        {%- do return([]) -%}
+    {%- endif -%}
 
-{%- do return(extracted_input_columns) -%}
+    {%- do return(extracted_input_columns) -%}
 
 {%- endmacro -%}
 
 
 {%- macro process_hash_column_excludes(hash_columns=none, source_columns=none) -%}
 
-{%- set processed_hash_columns = {} -%}
+    {%- set processed_hash_columns = {} -%}
 
-{%- for col, col_mapping in hash_columns.items() -%}
+    {%- for col, col_mapping in hash_columns.items() -%}
         
-{%- if col_mapping is mapping -%}
-{%- if col_mapping.exclude_columns -%}
+        {%- if col_mapping is mapping -%}
+            {%- if col_mapping.exclude_columns -%}
 
-{%- if col_mapping.columns -%}
+                {%- if col_mapping.columns -%}
 
                     {%- set columns_to_hash = datavault4dbt.process_columns_to_select(source_columns, col_mapping.columns) -%}
 
@@ -196,25 +196,25 @@
                 {%- do processed_hash_columns.update({col: col_mapping}) -%}
             {%- endif -%}
         {%- else -%}
-{%- do processed_hash_columns.update({col: col_mapping}) -%}
-{%- endif -%}
+            {%- do processed_hash_columns.update({col: col_mapping}) -%}
+        {%- endif -%}
 
-{%- endfor -%}
+    {%- endfor -%}
 
-{%- do return(processed_hash_columns) -%}
+    {%- do return(processed_hash_columns) -%}
 
 {%- endmacro -%}
 
 
 {%- macro print_list(list_to_print=none, indent=4, src_alias=none) -%}
 
-{%- for col_name in list_to_print -%}
-{%- if src_alias %}
+    {%- for col_name in list_to_print -%}
+        {%- if src_alias %}
         {{ (src_alias ~ '.' ~ col_name) | indent(indent) }}{{ "," if not loop.last }}
         {%- else %}
-{{ col_name | indent(indent) }}{{ "," if not loop.last }}
-{%- endif %}
-{%- endfor -%}
+        {{ col_name | indent(indent) }}{{ "," if not loop.last }}
+        {%- endif %}
+    {%- endfor -%}
 
 {%- endmacro -%}
 
@@ -223,28 +223,28 @@
     {# Check if the old syntax is used for prejoined columns
         If so parse it to new list syntax #}
 
-{% if datavault4dbt.is_list(prejoined_columns) %}
+    {% if datavault4dbt.is_list(prejoined_columns) %}
         {% do return(prejoined_columns) %}
     {% else %}
-{% set output = [] %}
+        {% set output = [] %}
 
-{% for key, value in prejoined_columns.items() %}
-{% set ref_model = value.get('ref_model') %}
-{% set src_name = value.get('src_name') %}
-{% set src_table = value.get('src_table') %}
-{%- if 'operator' not in value.keys() -%}  
+        {% for key, value in prejoined_columns.items() %}
+            {% set ref_model = value.get('ref_model') %}
+            {% set src_name = value.get('src_name') %}
+            {% set src_table = value.get('src_table') %}
+            {%- if 'operator' not in value.keys() -%}  
                 {%- do value.update({'operator': 'AND'}) -%}
                 {%- set operator = 'AND' -%}
             {%- else -%}
-{%- set operator = value.get('operator') -%}
-{%- endif -%}
-{%- if 'join_type' not in value.keys() -%}  
-                {%- do value.update({'join_type': 'LEFT'}) -%}
-                {%- set join_type = 'LEFT' -%}
-            {%- else -%}
-{%- set join_type = value.get('join_type') -%}
-{%- endif -%}
-            
+                {%- set operator = value.get('operator') -%}
+            {%- endif -%}
+            {%- if 'join_type' not in value.keys() -%}  
+                            {%- do value.update({'join_type': 'LEFT'}) -%}
+                            {%- set join_type = 'LEFT' -%}
+                        {%- else -%}
+            {%- set join_type = value.get('join_type') -%}
+            {%- endif -%}
+                        
     {% set match_criteria = (
             ref_model and output | selectattr('ref_model', 'equalto', ref_model) or
             src_name and output | selectattr('src_name', 'equalto', src_name) | selectattr('src_table', 'equalto', src_table)
@@ -254,7 +254,7 @@
         | selectattr('join_type', 'equalto', value.join_type)
         | list | first %}
         
-{% if match_criteria %}
+            {% if match_criteria %}
                 {% do match_criteria['extract_columns'].append(value.bk) %}
                 {% do match_criteria['aliases'].append(key) %}
             {% else %}
@@ -265,48 +265,48 @@
                     'ref_column_name': value.ref_column_name,
                     'operator': operator,
                     'join_type': join_type
-                } %}
+                } %}            
                 
-{% if ref_model %}
+                {% if ref_model %}
                     {% do new_item.update({'ref_model': ref_model}) %}
                 {% elif src_name and src_table %}
-{% do new_item.update({'src_name': src_name, 'src_table': src_table}) %}
-{% endif %}
+                    {% do new_item.update({'src_name': src_name, 'src_table': src_table}) %}
+                {% endif %}
                 
-{% do output.append(new_item) %}
-{% endif %}
-{% endfor %}
-{% endif %}
+                {% do output.append(new_item) %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 
-{%- do return(output) -%}
+    {%- do return(output) -%}
 
 {%- endmacro -%}
 
 
 {%- macro extract_prejoin_column_names(prejoined_columns=none) -%}
 
-{%- set extracted_column_names = [] -%}
+    {%- set extracted_column_names = [] -%}
     
-{% if not datavault4dbt.is_something(prejoined_columns) %}
-{%- do return(extracted_column_names) -%}
-{% endif %}
+    {% if not datavault4dbt.is_something(prejoined_columns) %}
+        {%- do return(extracted_column_names) -%}
+    {% endif %}
 
-{% for prejoin in prejoined_columns %}
-{% if datavault4dbt.is_list(prejoin['aliases']) %}
-{% for alias in prejoin['aliases'] %}
+    {% for prejoin in prejoined_columns %}
+        {% if datavault4dbt.is_list(prejoin['aliases']) %}
+            {% for alias in prejoin['aliases'] %}
                 {%- do extracted_column_names.append(alias) -%}
             {% endfor %}
         {% elif datavault4dbt.is_something(prejoin['aliases']) %}
             {%- do extracted_column_names.append(prejoin['aliases']) -%}
         {% elif datavault4dbt.is_list(prejoin['extract_columns']) %}
-{% for column in prejoin['extract_columns'] %}
+            {% for column in prejoin['extract_columns'] %}
                 {%- do extracted_column_names.append(column) -%}
             {% endfor %}
         {% else %}
-{%- do extracted_column_names.append(prejoin['extract_columns']) -%}
-{% endif %}
-{%- endfor -%}
+            {%- do extracted_column_names.append(prejoin['extract_columns']) -%}
+        {% endif %}
+    {%- endfor -%}
     
-{%- do return(extracted_column_names) -%}
+    {%- do return(extracted_column_names) -%}
 
 {%- endmacro -%}

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -1,141 +1,141 @@
 {%- macro process_columns_to_select(columns_list=none, exclude_columns_list=none) -%}
 
-    {{ return(adapter.dispatch('process_columns_to_select', 'datavault4dbt')(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
+{{ return(adapter.dispatch('process_columns_to_select', 'datavault4dbt')(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
 
 {%- endmacro -%}
 
 
 {%- macro default__process_columns_to_select(columns_list, exclude_columns_list) -%}
-    {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
-    {% set columns_list = columns_list | map('upper') | list %}
-    {% set columns_to_select = [] %}
+{% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
+{% set columns_list = columns_list | map('upper') | list %}
+{% set columns_to_select = [] %}
 
-    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
+{% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list) %}
 
-        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+{{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
 
-    {%- endif -%}
+{%- endif -%}
 
-    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
-        {%- for col in columns_list -%}
+{%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+{%- for col in columns_list -%}
 
-            {%- if col not in exclude_columns_list -%}
+{%- if col not in exclude_columns_list -%}
                 {%- do columns_to_select.append(col) -%}
             {%- endif -%}
 
         {%- endfor -%}
     {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
-        {% set columns_to_select = columns_list %}
-    {%- endif -%}
+{% set columns_to_select = columns_list %}
+{%- endif -%}
 
-    {%- do return(columns_to_select) -%}
+{%- do return(columns_to_select) -%}
 
 {%- endmacro -%}
 
     
 {%- macro fabric__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
-    {% set set_casing = var('datavault4dbt.set_casing', none) %}
-    {% if set_casing|lower in ['upper', 'uppercase'] %}
+{% set set_casing = var('datavault4dbt.set_casing', none) %}
+{% if set_casing|lower in ['upper', 'uppercase'] %}
         {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
         {% set columns_list = columns_list | map('upper') | list %}
     {% elif set_casing|lower in ['lower', 'lowercase'] %}
-        {% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
-        {% set columns_list = columns_list | map('lower') | list %}
-    {% endif %}
+{% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
+{% set columns_list = columns_list | map('lower') | list %}
+{% endif %}
 
-    {% set columns_to_select = [] %}
+{% set columns_to_select = [] %}
 
-    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
+{% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list) %}
 
-        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+{{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
 
-    {%- endif -%}
+{%- endif -%}
 
-    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
-        {%- for col in columns_list -%}
+{%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+{%- for col in columns_list -%}
 
-            {%- if col not in exclude_columns_list -%}
+{%- if col not in exclude_columns_list -%}
                 {%- do columns_to_select.append(col) -%}
             {%- endif -%}
 
         {%- endfor -%}
     {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
-        {% set columns_to_select = columns_list %}
-    {%- endif -%}
+{% set columns_to_select = columns_list %}
+{%- endif -%}
 
-    {%- do return(columns_to_select) -%}
+{%- do return(columns_to_select) -%}
 
 {%- endmacro -%}
 
 
 {%- macro databricks__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
-    {% set set_casing = var('datavault4dbt.set_casing', none) %}
-    {% if set_casing|lower in ['upper', 'uppercase'] %}
+{% set set_casing = var('datavault4dbt.set_casing', none) %}
+{% if set_casing|lower in ['upper', 'uppercase'] %}
         {% set exclude_columns_list = exclude_columns_list | map('upper') | list %}
         {% set columns_list = columns_list | map('upper') | list %}
     {% elif set_casing|lower in ['lower', 'lowercase'] %}
-        {% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
-        {% set columns_list = columns_list | map('lower') | list %}
-    {% endif %}
+{% set exclude_columns_list = exclude_columns_list | map('lower') | list %}
+{% set columns_list = columns_list | map('lower') | list %}
+{% endif %}
 
-    {% set columns_to_select = [] %}
+{% set columns_to_select = [] %}
 
-    {% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list)  %}
+{% if not datavault4dbt.is_list(columns_list) or not datavault4dbt.is_list(exclude_columns_list) %}
 
-        {{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
+{{- exceptions.raise_compiler_error("One or both arguments are not of list type.") -}}
 
-    {%- endif -%}
+{%- endif -%}
 
-    {%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
-        {%- for col in columns_list -%}
+{%- if datavault4dbt.is_something(columns_list) and datavault4dbt.is_something(exclude_columns_list) -%}
+{%- for col in columns_list -%}
 
-            {%- if col not in exclude_columns_list -%}
+{%- if col not in exclude_columns_list -%}
                 {%- do columns_to_select.append(col) -%}
             {%- endif -%}
 
         {%- endfor -%}
     {%- elif datavault4dbt.is_something(columns_list) and not datavault4dbt.is_something(exclude_columns_list) %}
-        {% set columns_to_select = columns_list %}
-    {%- endif -%}
+{% set columns_to_select = columns_list %}
+{%- endif -%}
 
-    {%- do return(columns_to_select) -%}
+{%- do return(columns_to_select) -%}
     
 {%- endmacro -%}
 
 
 {%- macro synapse__process_columns_to_select(columns_list, exclude_columns_list) -%}
 
-    {{ return (datavault4dbt.default__process_columns_to_select(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
+{{ return (datavault4dbt.default__process_columns_to_select(columns_list=columns_list,exclude_columns_list=exclude_columns_list)) }}
 
 {%- endmacro -%}
 
 
 {%- macro extract_column_names(columns_dict=none) -%}
 
-    {%- set extracted_column_names = [] -%}
+{%- set extracted_column_names = [] -%}
 
-    {%- if columns_dict is mapping -%}
-        {%- for key, value in columns_dict.items() -%}
+{%- if columns_dict is mapping -%}
+{%- for key, value in columns_dict.items() -%}
             {%- do extracted_column_names.append(key) -%}
         {%- endfor -%}
 
         {%- do return(extracted_column_names) -%}
     {%- else -%}
-        {%- do return([]) -%}
-    {%- endif -%}
+{%- do return([]) -%}
+{%- endif -%}
 
 {%- endmacro -%}
 
 {%- macro extract_input_columns(columns_dict=none) -%}
 
-    {%- set extracted_input_columns = [] -%}
+{%- set extracted_input_columns = [] -%}
 
-    {%- if columns_dict is mapping -%}
-        {%- for key, value in columns_dict.items() -%}
-            {%- if value is mapping and 'src_cols_required' in value.keys() -%}
-                {% if datavault4dbt.is_list(value['src_cols_required']) %}
+{%- if columns_dict is mapping -%}
+{%- for key, value in columns_dict.items() -%}
+{%- if value is mapping and 'src_cols_required' in value.keys() -%}
+{% if datavault4dbt.is_list(value['src_cols_required']) %}
                     {% set extracted_input_columns = extracted_input_columns + value['src_cols_required'] %}
                 {% else %}
                     {%- do extracted_input_columns.append(value['src_cols_required']) -%}
@@ -150,9 +150,9 @@
         {%- endfor -%}
     
     {%- elif datavault4dbt.is_list(columns_dict) -%}
-        {% for prejoin in columns_dict %}
-            {%- if datavault4dbt.is_list(prejoin['this_column_name'])-%}
-                {%- for column in prejoin['this_column_name'] -%}
+{% for prejoin in columns_dict %}
+{%- if datavault4dbt.is_list(prejoin['this_column_name']) -%}
+{%- for column in prejoin['this_column_name'] -%}
                     {%- do extracted_input_columns.append(column) -%}
                 {%- endfor -%}
             {%- else -%}
@@ -160,24 +160,24 @@
             {%- endif -%}
         {% endfor %}
     {%- else -%}
-        {%- do return([]) -%}
-    {%- endif -%}
+{%- do return([]) -%}
+{%- endif -%}
 
-    {%- do return(extracted_input_columns) -%}
+{%- do return(extracted_input_columns) -%}
 
 {%- endmacro -%}
 
 
 {%- macro process_hash_column_excludes(hash_columns=none, source_columns=none) -%}
 
-    {%- set processed_hash_columns = {} -%}
+{%- set processed_hash_columns = {} -%}
 
-    {%- for col, col_mapping in hash_columns.items() -%}
+{%- for col, col_mapping in hash_columns.items() -%}
         
-        {%- if col_mapping is mapping -%}
-            {%- if col_mapping.exclude_columns -%}
+{%- if col_mapping is mapping -%}
+{%- if col_mapping.exclude_columns -%}
 
-                {%- if col_mapping.columns -%}
+{%- if col_mapping.columns -%}
 
                     {%- set columns_to_hash = datavault4dbt.process_columns_to_select(source_columns, col_mapping.columns) -%}
 
@@ -196,25 +196,25 @@
                 {%- do processed_hash_columns.update({col: col_mapping}) -%}
             {%- endif -%}
         {%- else -%}
-            {%- do processed_hash_columns.update({col: col_mapping}) -%}
-        {%- endif -%}
+{%- do processed_hash_columns.update({col: col_mapping}) -%}
+{%- endif -%}
 
-    {%- endfor -%}
+{%- endfor -%}
 
-    {%- do return(processed_hash_columns) -%}
+{%- do return(processed_hash_columns) -%}
 
 {%- endmacro -%}
 
 
 {%- macro print_list(list_to_print=none, indent=4, src_alias=none) -%}
 
-    {%- for col_name in list_to_print -%}
-        {%- if src_alias %}
+{%- for col_name in list_to_print -%}
+{%- if src_alias %}
         {{ (src_alias ~ '.' ~ col_name) | indent(indent) }}{{ "," if not loop.last }}
         {%- else %}
-        {{ col_name | indent(indent) }}{{ "," if not loop.last }}
-        {%- endif %}
-    {%- endfor -%}
+{{ col_name | indent(indent) }}{{ "," if not loop.last }}
+{%- endif %}
+{%- endfor -%}
 
 {%- endmacro -%}
 
@@ -223,21 +223,27 @@
     {# Check if the old syntax is used for prejoined columns
         If so parse it to new list syntax #}
 
-    {% if datavault4dbt.is_list(prejoined_columns) %}
+{% if datavault4dbt.is_list(prejoined_columns) %}
         {% do return(prejoined_columns) %}
     {% else %}
-        {% set output = [] %}
+{% set output = [] %}
 
-        {% for key, value in prejoined_columns.items() %}
-            {% set ref_model = value.get('ref_model') %}
-            {% set src_name = value.get('src_name') %}
-            {% set src_table = value.get('src_table') %}
-            {%- if 'operator' not in value.keys() -%}  
+{% for key, value in prejoined_columns.items() %}
+{% set ref_model = value.get('ref_model') %}
+{% set src_name = value.get('src_name') %}
+{% set src_table = value.get('src_table') %}
+{%- if 'operator' not in value.keys() -%}  
                 {%- do value.update({'operator': 'AND'}) -%}
                 {%- set operator = 'AND' -%}
             {%- else -%}
-                {%- set operator = value.get('operator') -%}
-            {%- endif -%}
+{%- set operator = value.get('operator') -%}
+{%- endif -%}
+{%- if 'join_type' not in value.keys() -%}  
+                {%- do value.update({'join_type': 'LEFT'}) -%}
+                {%- set join_type = 'LEFT' -%}
+            {%- else -%}
+{%- set join_type = value.get('join_type') -%}
+{%- endif -%}
             
     {% set match_criteria = (
             ref_model and output | selectattr('ref_model', 'equalto', ref_model) or
@@ -245,9 +251,10 @@
         ) | selectattr('this_column_name', 'equalto', value.this_column_name)
         | selectattr('ref_column_name', 'equalto', value.ref_column_name)
         | selectattr('operator', 'equalto', value.operator)
+        | selectattr('join_type', 'equalto', value.join_type)
         | list | first %}
         
-            {% if match_criteria %}
+{% if match_criteria %}
                 {% do match_criteria['extract_columns'].append(value.bk) %}
                 {% do match_criteria['aliases'].append(key) %}
             {% else %}
@@ -256,49 +263,50 @@
                     'aliases': [key],
                     'this_column_name': value.this_column_name,
                     'ref_column_name': value.ref_column_name,
-                    'operator': operator
+                    'operator': operator,
+                    'join_type': join_type
                 } %}
                 
-                {% if ref_model %}
+{% if ref_model %}
                     {% do new_item.update({'ref_model': ref_model}) %}
                 {% elif src_name and src_table %}
-                    {% do new_item.update({'src_name': src_name, 'src_table': src_table}) %}
-                {% endif %}
+{% do new_item.update({'src_name': src_name, 'src_table': src_table}) %}
+{% endif %}
                 
-                {% do output.append(new_item) %}
-            {% endif %}
-        {% endfor %}
-    {% endif %}
+{% do output.append(new_item) %}
+{% endif %}
+{% endfor %}
+{% endif %}
 
-    {%- do return(output) -%}
+{%- do return(output) -%}
 
 {%- endmacro -%}
 
 
 {%- macro extract_prejoin_column_names(prejoined_columns=none) -%}
 
-    {%- set extracted_column_names = [] -%}
+{%- set extracted_column_names = [] -%}
     
-    {% if not datavault4dbt.is_something(prejoined_columns) %}
-        {%- do return(extracted_column_names) -%}
-    {% endif %}
+{% if not datavault4dbt.is_something(prejoined_columns) %}
+{%- do return(extracted_column_names) -%}
+{% endif %}
 
-    {% for prejoin in prejoined_columns %}
-        {% if datavault4dbt.is_list(prejoin['aliases']) %}
-            {% for alias in prejoin['aliases'] %}
+{% for prejoin in prejoined_columns %}
+{% if datavault4dbt.is_list(prejoin['aliases']) %}
+{% for alias in prejoin['aliases'] %}
                 {%- do extracted_column_names.append(alias) -%}
             {% endfor %}
         {% elif datavault4dbt.is_something(prejoin['aliases']) %}
             {%- do extracted_column_names.append(prejoin['aliases']) -%}
         {% elif datavault4dbt.is_list(prejoin['extract_columns']) %}
-            {% for column in prejoin['extract_columns'] %}
+{% for column in prejoin['extract_columns'] %}
                 {%- do extracted_column_names.append(column) -%}
             {% endfor %}
         {% else %}
-            {%- do extracted_column_names.append(prejoin['extract_columns']) -%}
-        {% endif %}
-    {%- endfor -%}
+{%- do extracted_column_names.append(prejoin['extract_columns']) -%}
+{% endif %}
+{%- endfor -%}
     
-    {%- do return(extracted_column_names) -%}
+{%- do return(extracted_column_names) -%}
 
 {%- endmacro -%}

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -239,8 +239,8 @@
                 {%- set operator = value.get('operator') -%}
             {%- endif -%}
             {%- if 'join_type' not in value.keys() -%}  
-                            {%- do value.update({'join_type': 'LEFT'}) -%}
-                            {%- set join_type = 'LEFT' -%}
+                            {%- do value.update({'join_type': 'left'}) -%}
+                            {%- set join_type = 'left' -%}
                         {%- else -%}
             {%- set join_type = value.get('join_type') -%}
             {%- endif -%}

--- a/macros/staging/synapse/stage.sql
+++ b/macros/staging/synapse/stage.sql
@@ -335,9 +335,14 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+    {%- if 'join_type' not in prejoin.keys() -%}
+      {%- set join_type = 'LEFT' -%}
+    {%- else -%}
+      {%- set join_type = prejoin['join_type'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      left join {{ relation }} as {{ prejoin_alias }}
+      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
         on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 

--- a/macros/staging/synapse/stage.sql
+++ b/macros/staging/synapse/stage.sql
@@ -336,7 +336,7 @@ prejoined_columns AS (
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
     {%- if 'join_type' not in prejoin.keys() -%}
-      {%- set join_type = 'LEFT' -%}
+      {%- set join_type = 'left' -%}
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}


### PR DESCRIPTION
This Pull Request handles the new feature which is described here: https://github.com/ScalefreeCOM/datavault4dbt/issues/348
@tkiehn @tkirschke Would be happy if you might take a look into it and tell me your opinion :)

# Description

Adds a new Parameter called "join_type" for Prejoining. It allows user to define in specific usecases a Join-Type different than LEFT Join. However, if the parameter is not set, left join is taken as default. Due to that there shouldn't be any issues with backward compatibility.

Examples for now supported Join Types: INNER, LEFT, RIGHT, CROSS, OUTER, FULL

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested it on Databricks Environment and checked the compiled Code of existing Staging model in the following usecases:

- [x] without new Parameter -> Default value works
- [x] with new Parameter and value INNER -> was successfully compiled as Inner Join
- [x] staging model with mixed setup, one join with parameter and one without -> was successfully compiled with inner join and left join

**Test Configuration**:
* datavault4dbt-Version: 1.9.10
* dbt-Version: core, 1.10.9
* dbt-adapter-Version: dbt-databricks, 1.10.10

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
