### PR TITLE
FIX: 352 bug stage macro fails for ms fabric when source table has more than 127 columns

### DIFF
--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -392,6 +392,8 @@
     {%- set attribute_standardise = datavault4dbt.attribute_standardise(hash_type='hashkey') %}
 {%- endif -%}
 
+{{ log('attribute_standardise: '~attribute_standardise, false)}}
+
 {#- If single column to hash -#}
 {%- if columns is string -%}
     {%- set columns = [columns] -%}
@@ -399,7 +401,7 @@
 
 {%- set all_null = [] -%}
 
-{%- if is_hashdiff  and datavault4dbt.is_something(multi_active_key) -%}
+{%- if is_hashdiff and datavault4dbt.is_something(multi_active_key) -%}
     {%- set std_dict = fromjson(datavault4dbt.multi_active_concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key, multi_active_key=multi_active_key, main_hashkey_column=main_hashkey_column)) -%}
 {%- elif is_hashdiff -%}
     {%- set std_dict = fromjson(datavault4dbt.concattenated_standardise(case_sensitive=hashdiff_input_case_sensitive, hash_alg=hash_alg, datatype=hash_dtype, alias=alias, zero_key=unknown_key)) -%}
@@ -410,7 +412,7 @@
     {%- set standardise_prefix = std_dict['standardise_prefix'] -%}
     {%- set standardise_suffix = std_dict['standardise_suffix'] -%}
 
-{{ standardise_prefix }}
+{{ standardise_prefix | replace('[CONCAT_STRING]', concat_string) }}
 
 {%- for column in columns -%}
 
@@ -421,10 +423,9 @@
     {%- else -%}
         {%- set column_str = datavault4dbt.as_constant(column) -%}
     {%- endif -%}
-    {{ log('attribute_standardise: '~attribute_standardise, false)}}
 
     {{- "\nISNULL(({}), '{}')".format(attribute_standardise | replace('[EXPRESSION]', column_str) | replace('[QUOTE]', quote) | replace('[NULL_PLACEHOLDER_STRING]', null_placeholder_string), null_placeholder_string) | indent(4) -}}
-    {{- ",'{}',".format(concat_string) if not loop.last -}}
+    {{- ", " if not loop.last -}}
     {{- ", ''" if columns|length == 1 -}}
 
     {%- if loop.last -%}

--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -412,7 +412,13 @@
     {%- set standardise_prefix = std_dict['standardise_prefix'] -%}
     {%- set standardise_suffix = std_dict['standardise_suffix'] -%}
 
-{{ standardise_prefix | replace('[CONCAT_STRING]', concat_string) }}
+{%- if columns | length == 1 -%}
+    {%- set concat_function = 'CONCAT(' -%}
+{%- elif columns | length > 1 -%}
+    {%- set concat_function = 'CONCAT_WS(\'' ~ concat_string ~ '\', ' -%}
+{%- endif -%}
+
+{{ standardise_prefix | replace('[CONCAT_FUNCTION]', concat_function) }}
 
 {%- for column in columns -%}
 

--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -387,7 +387,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
 
     {%- if case_sensitive -%}
     
-        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(CONCAT(".format(hash_alg)-%} 
+        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(CONCAT_WS('[CONCAT_STRING]',".format(hash_alg)-%} 
         {%- if alias is not none -%}    
             {%- set standardise_suffix = "), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))), {}) AS {}".format(zero_key, alias)-%} 
         {%- else -%}
@@ -395,7 +395,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
         {%- endif -%}    
     {%- else -%}
 
-        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(CONCAT(".format(hash_alg)-%} 
+        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(CONCAT_WS('[CONCAT_STRING]',".format(hash_alg)-%} 
         {%- if alias is not none -%} 
             {%- set standardise_suffix = ")), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))), {}) AS {}".format(zero_key, alias)-%} 
         {%- else -%}
@@ -405,7 +405,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
 {%- else -%}
         {%- if case_sensitive -%} 
     
-        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(CONCAT(".format(datatype, hash_alg)-%}
+        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(CONCAT_WS('[CONCAT_STRING]',".format(datatype, hash_alg)-%}
         {%- if alias is not none -%}    
             {%- set standardise_suffix = "), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))),1), CAST({} as {})) AS {}".format(zero_key, datatype, alias)-%}
         {%- else -%}
@@ -414,7 +414,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
     {%- else -%}
 
 
-        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(CONCAT(".format(datatype, hash_alg)-%}
+        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(CONCAT_WS('[CONCAT_STRING]',".format(datatype, hash_alg)-%}
         {%- if alias is not none -%}
             {%- set standardise_suffix = ")), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))),1), CAST({} as {})) AS {}".format(zero_key, datatype, alias)-%}
 

--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -387,7 +387,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
 
     {%- if case_sensitive -%}
     
-        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(CONCAT_WS('[CONCAT_STRING]',".format(hash_alg)-%} 
+        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE([CONCAT_FUNCTION]".format(hash_alg)-%} 
         {%- if alias is not none -%}    
             {%- set standardise_suffix = "), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))), {}) AS {}".format(zero_key, alias)-%} 
         {%- else -%}
@@ -395,7 +395,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
         {%- endif -%}    
     {%- else -%}
 
-        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(CONCAT_WS('[CONCAT_STRING]',".format(hash_alg)-%} 
+        {%- set standardise_prefix = "ISNULL(HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER([CONCAT_FUNCTION]".format(hash_alg)-%} 
         {%- if alias is not none -%} 
             {%- set standardise_suffix = ")), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))), {}) AS {}".format(zero_key, alias)-%} 
         {%- else -%}
@@ -405,7 +405,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
 {%- else -%}
         {%- if case_sensitive -%} 
     
-        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(CONCAT_WS('[CONCAT_STRING]',".format(datatype, hash_alg)-%}
+        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE([CONCAT_FUNCTION]".format(datatype, hash_alg)-%}
         {%- if alias is not none -%}    
             {%- set standardise_suffix = "), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))),1), CAST({} as {})) AS {}".format(zero_key, datatype, alias)-%}
         {%- else -%}
@@ -414,7 +414,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(TRIM(CAST([EXPRESSION] AS STR
     {%- else -%}
 
 
-        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(CONCAT_WS('[CONCAT_STRING]',".format(datatype, hash_alg)-%}
+        {%- set standardise_prefix = "ISNULL(CONVERT({}, HASHBYTES('{}', (NULLIF(CAST(REPLACE(REPLACE(REPLACE(REPLACE(UPPER([CONCAT_FUNCTION]".format(datatype, hash_alg)-%}
         {%- if alias is not none -%}
             {%- set standardise_suffix = ")), CHAR(10), ''), CHAR(9), ''), CHAR(11), ''), CHAR(13), '') AS VARCHAR(4000)), '[ALL_NULL]'))),1), CAST({} as {})) AS {}".format(zero_key, datatype, alias)-%}
 

--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -69,7 +69,7 @@ CONCAT('\"', REPLACE(REPLACE(REPLACE(TRIM(CAST([EXPRESSION] AS STRING)), '\\', '
 
 {%- else -%}
 
-    CONCAT('"', REPLACE(REPLACE(REPLACE(LTRIM(RTRIM([EXPRESSION])), '\\', '\\\\'), '[QUOTE]', '\"'), '[NULL_PLACEHOLDER_STRING]', '--'), '"')
+    CONCAT('"', REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(CONVERT(VARCHAR(4000), [EXPRESSION], 1))), '\\', '\\\\'), '[QUOTE]', '\"'), '[NULL_PLACEHOLDER_STRING]', '--'), '"')
 
 {%- endif -%}
 


### PR DESCRIPTION
# Description

Due to the `concat()` function allowing a maximum of 254 arguments it was only possible to specify 127 columns for a hashdiff.
By switching to `concat_ws()` the maximum number of columns for a hashdiff is now 253.
Thanks to @dga-isr for pointing this out and proposing the fix using `concat_ws()`!

Additionally the hashdiff-standardization now also includes a `CAST()` to Varchar to allow varbinary payloads.

Fixes #352 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update -> add information about max amount of columns (253) for MS Fabric


# Checklist:
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
