### PR TITLE
fix: fabric: remove lower in partition by clause of ma_sat_v0

### DIFF
--- a/macros/tables/fabric/ma_sat_v0.sql
+++ b/macros/tables/fabric/ma_sat_v0.sql
@@ -57,7 +57,7 @@ latest_entries_in_sat_prep AS (
     SELECT
         {{ parent_hashkey }},
         {{ ns.hdiff_alias }},
-        ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) as rn
+        ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
     FROM 
         {{ this }}
 ),


### PR DESCRIPTION
# Description

fix: fabric: remove lower in partition by clause of ma_sat_v0 which produced errors when hashkeys were not defined in lowercase

Fixes #356

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)