### PR TITLE
343-additional-columns-for-hub-and-links

### DIFF
--- a/macros/tables/bigquery/hub.sql
+++ b/macros/tables/bigquery/hub.sql
@@ -1,4 +1,4 @@
-{%- macro default__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro default__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
@@ -9,6 +9,9 @@
 
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
+
+{# Select the additional_columns values from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -24,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -151,7 +154,8 @@ WITH
             {% endfor -%}
 
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -192,7 +196,8 @@ source_new_union AS (
         {% endfor -%}
 
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/bigquery/hub.sql
+++ b/macros/tables/bigquery/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -153,9 +153,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,9 +198,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/bigquery/link.sql
+++ b/macros/tables/bigquery/link.sql
@@ -1,5 +1,5 @@
 
-{%- macro default__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro default__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -14,6 +14,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -27,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -155,7 +158,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,7 +199,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/bigquery/link.sql
+++ b/macros/tables/bigquery/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/bigquery/link.sql
+++ b/macros/tables/bigquery/link.sql
@@ -15,7 +15,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -30,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -157,9 +157,14 @@ WITH
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
+        {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -198,9 +203,13 @@ source_new_union AS (
         {% for fk in source_model['fk_columns']|list %}
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/bigquery/link.sql
+++ b/macros/tables/bigquery/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/bigquery/nh_link.sql
+++ b/macros/tables/bigquery/nh_link.sql
@@ -1,9 +1,12 @@
-{%- macro default__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro default__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -41,7 +44,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -170,7 +173,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -216,7 +219,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/bigquery/nh_link.sql
+++ b/macros/tables/bigquery/nh_link.sql
@@ -5,7 +5,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}

--- a/macros/tables/databricks/hub.sql
+++ b/macros/tables/databricks/hub.sql
@@ -36,8 +36,6 @@
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set additional_columns = datavault4dbt.escape_column_names(additional_columns) -%}
 
-
-
 {{ datavault4dbt.prepend_generated_by() }}
 
 WITH

--- a/macros/tables/databricks/hub.sql
+++ b/macros/tables/databricks/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns -%}
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 
 {%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
@@ -160,9 +160,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -202,9 +205,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/databricks/link.sql
+++ b/macros/tables/databricks/link.sql
@@ -30,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc]  + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
@@ -38,7 +38,6 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set additional_columns = datavault4dbt.escape_column_names(additional_columns) -%}
-
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/databricks/link.sql
+++ b/macros/tables/databricks/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/databricks/link.sql
+++ b/macros/tables/databricks/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/databricks/link.sql
+++ b/macros/tables/databricks/link.sql
@@ -14,8 +14,8 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -30,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
@@ -164,9 +164,13 @@ WITH
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -205,9 +209,13 @@ source_new_union AS (
         {% for fk in source_model['fk_columns']|list %}
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/databricks/nh_link.sql
+++ b/macros/tables/databricks/nh_link.sql
@@ -6,8 +6,8 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -43,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns + payload -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
@@ -174,13 +174,17 @@ WITH
 src_new_{{ source_number }} AS (
 
     SELECT
-            {{ datavault4dbt.escape_column_names(link_hk) }} AS {{ link_hashkey }},
-            {% for fk in source_model['fk_columns'] -%}
-            {{ datavault4dbt.escape_column_names(fk) }},
-            {% endfor -%}
+        {{ datavault4dbt.escape_column_names(link_hk) }} AS {{ link_hashkey }},
+        {% for fk in source_model['fk_columns'] -%}
+        {{ datavault4dbt.escape_column_names(fk) }},
+        {% endfor -%}
+
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
+        {{ src_rsrc }}
         {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_model['payload'])) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -224,9 +228,12 @@ source_new_union AS (
             {{ datavault4dbt.escape_column_names(fk) }} AS {{ datavault4dbt.escape_column_names(foreign_hashkeys[loop.index - 1]) }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
+        {{ src_rsrc }}
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/databricks/nh_link.sql
+++ b/macros/tables/databricks/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
 
-{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}

--- a/macros/tables/exasol/hub.sql
+++ b/macros/tables/exasol/hub.sql
@@ -8,8 +8,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -25,7 +25,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/exasol/hub.sql
+++ b/macros/tables/exasol/hub.sql
@@ -1,4 +1,4 @@
-{%- macro exasol__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro exasol__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}

--- a/macros/tables/exasol/link.sql
+++ b/macros/tables/exasol/link.sql
@@ -14,7 +14,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -29,7 +29,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc]  + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc]  + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 

--- a/macros/tables/exasol/link.sql
+++ b/macros/tables/exasol/link.sql
@@ -1,4 +1,4 @@
-{%- macro exasol__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro exasol__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 

--- a/macros/tables/exasol/link.sql
+++ b/macros/tables/exasol/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/exasol/link.sql
+++ b/macros/tables/exasol/link.sql
@@ -13,6 +13,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -26,7 +29,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc]  + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -154,7 +157,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -194,7 +198,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/exasol/link.sql
+++ b/macros/tables/exasol/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/exasol/nh_link.sql
+++ b/macros/tables/exasol/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -43,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -170,9 +170,13 @@ src_new_{{ source_number }} AS (
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -216,9 +220,12 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/exasol/nh_link.sql
+++ b/macros/tables/exasol/nh_link.sql
@@ -1,9 +1,12 @@
-{%- macro exasol__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro exasol__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -40,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -169,7 +172,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -215,7 +218,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/exasol/nh_link.sql
+++ b/macros/tables/exasol/nh_link.sql
@@ -5,7 +5,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}

--- a/macros/tables/fabric/hub.sql
+++ b/macros/tables/fabric/hub.sql
@@ -1,4 +1,4 @@
-{%- macro fabric__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro fabric__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
@@ -9,6 +9,9 @@
 
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
+
+{# Select the additional_columns values from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -24,13 +27,13 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
 {%- set business_keys = datavault4dbt.escape_column_names(business_keys) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
-
+{%- set additional_columns = datavault4dbt.escape_column_names(additional_columns) -%}
 
 WITH
 
@@ -157,7 +160,8 @@ WITH
             {% endfor -%}
 
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -198,7 +202,8 @@ source_new_union AS (
         {% endfor -%}
 
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/fabric/hub.sql
+++ b/macros/tables/fabric/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
 {%- set business_keys = datavault4dbt.escape_column_names(business_keys) -%}
@@ -159,9 +159,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -201,9 +204,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/fabric/link.sql
+++ b/macros/tables/fabric/link.sql
@@ -1,4 +1,4 @@
-{%- macro fabric__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro fabric__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -13,6 +13,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -26,13 +29,14 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
 {%- set foreign_hashkeys = datavault4dbt.escape_column_names(foreign_hashkeys) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
+{%- set additional_columns = datavault4dbt.escape_column_names(additional_columns) -%}
 
 WITH
 
@@ -160,7 +164,8 @@ WITH
             {{ datavault4dbt.escape_column_names(fk) }},
             {% endfor -%}
             {{ (src_ldts) }},
-            {{ (src_rsrc) }}
+            {{ (src_rsrc) }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -200,7 +205,8 @@ source_new_union AS (
             {{ (fk) }} AS {{ (foreign_hashkeys[loop.index - 1]) }},
         {% endfor -%}
         {{ (src_ldts) }},
-        {{ (src_rsrc) }}
+        {{ (src_rsrc) }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/fabric/link.sql
+++ b/macros/tables/fabric/link.sql
@@ -14,7 +14,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -29,7 +29,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}

--- a/macros/tables/fabric/link.sql
+++ b/macros/tables/fabric/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/fabric/link.sql
+++ b/macros/tables/fabric/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/fabric/nh_link.sql
+++ b/macros/tables/fabric/nh_link.sql
@@ -1,4 +1,4 @@
-{%- macro fabric__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro fabric__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
@@ -6,6 +6,8 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -41,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
@@ -177,7 +179,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_model['payload'])) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -223,7 +225,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ (col) }} AS {{ (payload[loop.index - 1]) }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/fabric/nh_link.sql
+++ b/macros/tables/fabric/nh_link.sql
@@ -7,7 +7,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -43,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  + payload -%}
 
 {%- set final_columns_to_select = datavault4dbt.escape_column_names(final_columns_to_select) -%}
 {%- set link_hashkey = datavault4dbt.escape_column_names(link_hashkey) -%}
@@ -177,9 +177,13 @@ src_new_{{ source_number }} AS (
             {% for fk in source_model['fk_columns'] -%}
             {{ datavault4dbt.escape_column_names(fk) }},
             {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_model['payload'])) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -223,9 +227,12 @@ source_new_union AS (
             {{ datavault4dbt.escape_column_names(fk) }} AS {{ datavault4dbt.escape_column_names(foreign_hashkeys[loop.index - 1]) }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ (col) }} AS {{ (payload[loop.index - 1]) }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/fabric/nh_link.sql
+++ b/macros/tables/fabric/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}

--- a/macros/tables/hub.sql
+++ b/macros/tables/hub.sql
@@ -10,7 +10,7 @@
 #}
 
 
-{%- macro hub(yaml_metadata=none, hashkey=none, business_keys=none, source_models=none, src_ldts=none, src_rsrc=none, disable_hwm=false) -%}
+{%- macro hub(yaml_metadata=none, hashkey=none, business_keys=none, source_models=none, src_ldts=none, src_rsrc=none, disable_hwm=false, additional_columns=none) -%}
 
     {% set hashkey_description = "
     hashkey::string                             Name of the hashkey column inside the stage, that should be used as PK of the Hub.
@@ -85,13 +85,19 @@
                                 Needs to use the same column name as defined as alias inside the staging model.
     " %}
 
+    {% set additional_columns_description = "
+    additional_columns_description::string            Additional columns from source system or derived columns which should be part of Hub. Useful when you have to deviate from the normal Hub Structure due to organisational or governancance reasons (Multitenant, BKCC, ..). Is optional and as default the normal Hub columns are applied.
+                                                      Columns needs to be in all source models which are used for the Hub.
+    " %}
+
     {%- set hashkey         = datavault4dbt.yaml_metadata_parser(name='hashkey', yaml_metadata=yaml_metadata, parameter=hashkey, required=True, documentation=hashkey_description) -%}
     {%- set business_keys   = datavault4dbt.yaml_metadata_parser(name='business_keys', yaml_metadata=yaml_metadata, parameter=business_keys, required=True, documentation=business_keys_description) -%}
     {%- set source_models   = datavault4dbt.yaml_metadata_parser(name='source_models', yaml_metadata=yaml_metadata, parameter=source_models, required=True, documentation=source_models_description) -%}
     {%- set src_ldts        = datavault4dbt.yaml_metadata_parser(name='src_ldts', yaml_metadata=yaml_metadata, parameter=src_ldts, required=False, documentation=src_ldts_description) -%}
     {%- set src_rsrc        = datavault4dbt.yaml_metadata_parser(name='src_rsrc', yaml_metadata=yaml_metadata, parameter=src_rsrc, required=False, documentation=src_rsrc_description) -%}
     {%- set disable_hwm     = datavault4dbt.yaml_metadata_parser(name='disable_hwm', yaml_metadata=yaml_metadata, parameter=disable_hwm, required=False, documentation='Whether the High Water Mark should be turned off. Optional, default False.') -%}
-
+    {%- set additional_columns     = datavault4dbt.yaml_metadata_parser(name='additional_columns', yaml_metadata=yaml_metadata, parameter=additional_columns, required=False, documentation=additional_columns_description) -%}
+    
     {# Applying the default aliases as stored inside the global variables, if src_ldts and src_rsrc are not set. #}
 
     {%- set src_ldts = datavault4dbt.replace_standard(src_ldts, 'datavault4dbt.ldts_alias', 'ldts') -%}
@@ -102,6 +108,7 @@
                                                             src_ldts=src_ldts,
                                                             src_rsrc=src_rsrc,
                                                             source_models=source_models,
-                                                            disable_hwm=disable_hwm)) }}
+                                                            disable_hwm=disable_hwm,
+                                                            additional_columns=additional_columns)) }}
 
 {%- endmacro -%}

--- a/macros/tables/link.sql
+++ b/macros/tables/link.sql
@@ -77,12 +77,18 @@
                                             Needs to use the same column name as defined as alias inside the staging model.
     " %}
 
+    {% set additional_columns_description = "
+    additional_columns_description::string            Additional columns from source system or derived columns which should be part of Link. Useful when you have to deviate from the normal Link Structure due to organisational or governancance reasons (Multitenant, BKCC, ..). Is optional and as default the normal Link columns are applied.
+                                                      Columns needs to be in all source models which are used for the Link.
+    " %}
+
     {%- set link_hashkey        = datavault4dbt.yaml_metadata_parser(name='link_hashkey', yaml_metadata=yaml_metadata, parameter=link_hashkey, required=True, documentation=link_hashkey_description) -%}
     {%- set foreign_hashkeys    = datavault4dbt.yaml_metadata_parser(name='foreign_hashkeys', yaml_metadata=yaml_metadata, parameter=foreign_hashkeys, required=True, documentation=foreign_hashkeys_description) -%}
     {%- set source_models       = datavault4dbt.yaml_metadata_parser(name='source_models', yaml_metadata=yaml_metadata, parameter=source_models, required=True, documentation=source_models_description) -%}
     {%- set src_ldts            = datavault4dbt.yaml_metadata_parser(name='src_ldts', yaml_metadata=yaml_metadata, parameter=src_ldts, required=False, documentation=src_ldts_description) -%}
     {%- set src_rsrc            = datavault4dbt.yaml_metadata_parser(name='src_rsrc', yaml_metadata=yaml_metadata, parameter=src_rsrc, required=False, documentation=src_rsrc_description) -%}
     {%- set disable_hwm         = datavault4dbt.yaml_metadata_parser(name='disable_hwm', yaml_metadata=yaml_metadata, parameter=disable_hwm, required=False, documentation='Whether the High Water Mark should be turned off. Optional, default False.') -%}
+    {%- set additional_columns     = datavault4dbt.yaml_metadata_parser(name='additional_columns', yaml_metadata=yaml_metadata, parameter=additional_columns, required=False, documentation=additional_columns_description) -%}
 
     {# Applying the default aliases as stored inside the global variables, if src_ldts and src_rsrc are not set. #}
 
@@ -92,6 +98,7 @@
     {{- adapter.dispatch('link', 'datavault4dbt')(link_hashkey=link_hashkey, foreign_hashkeys=foreign_hashkeys,
                                              src_ldts=src_ldts, src_rsrc=src_rsrc,
                                              source_models=source_models,
-                                             disable_hwm=disable_hwm) -}}
+                                             disable_hwm=disable_hwm,
+                                             additional_columns=additional_columns) -}}
 
 {%- endmacro -%}

--- a/macros/tables/link.sql
+++ b/macros/tables/link.sql
@@ -5,7 +5,7 @@
     all have the same number of foreign keys inside, otherwise they would not share the same business definition of that link.
 #}
 
-{%- macro link(yaml_metadata=none, link_hashkey=none, foreign_hashkeys=none, source_models=none, src_ldts=none, src_rsrc=none, disable_hwm=false) -%}
+{%- macro link(yaml_metadata=none, link_hashkey=none, foreign_hashkeys=none, source_models=none, src_ldts=none, src_rsrc=none, disable_hwm=false, additional_columns=none) -%}
 
     {% set link_hashkey_description = "
     link_hashkey::string                    Name of the link hashkey column inside the stage. Should get calculated out of all business keys inside

--- a/macros/tables/nh_link.sql
+++ b/macros/tables/nh_link.sql
@@ -6,7 +6,7 @@
     In the background a non-historized link uses exactly the same loading logic as a regular link, but adds the descriptive attributes as additional payload.
 #}
 
-{%- macro nh_link(yaml_metadata=none, link_hashkey=none, payload=none, source_models=none, foreign_hashkeys=none, src_ldts=none, src_rsrc=none, disable_hwm=false, source_is_single_batch=false, union_strategy='all') -%}
+{%- macro nh_link(yaml_metadata=none, link_hashkey=none, payload=none, source_models=none, foreign_hashkeys=none, src_ldts=none, src_rsrc=none, disable_hwm=false, source_is_single_batch=false, union_strategy='all', additional_columns=none) -%}
     
     {% set link_hashkey_description = "
     link_hashkey::string                    Name of the non-historized link hashkey column inside the stage. Should get calculated out of all business keys inside
@@ -97,6 +97,11 @@
                                             source systems, and don't want to deduplicate them upfront. 
     " %}
 
+    {% set additional_columns_description = "
+    additional_columns_description::string            Additional columns from source system or derived columns which should be part of NH-Link. Useful when you have to deviate from the normal NH-Link Structure due to organisational or governancance reasons (Multitenant, BKCC, ..). Is optional and as default the normal NH-Link columns are applied.
+                                                      Columns needs to be in all source models which are used for the Non-historized Link.
+    " %}
+
     {%- set link_hashkey            = datavault4dbt.yaml_metadata_parser(name='link_hashkey', yaml_metadata=yaml_metadata, parameter=link_hashkey, required=True, documentation=link_hashkey_description) -%}
     {%- set payload                 = datavault4dbt.yaml_metadata_parser(name='payload', yaml_metadata=yaml_metadata, parameter=payload, required=True, documentation=payload_description) -%}
     {%- set source_models           = datavault4dbt.yaml_metadata_parser(name='source_models', yaml_metadata=yaml_metadata, parameter=source_models, required=True, documentation=source_models_description) -%}
@@ -106,6 +111,7 @@
     {%- set disable_hwm             = datavault4dbt.yaml_metadata_parser(name='disable_hwm', yaml_metadata=yaml_metadata, parameter=disable_hwm, required=False, documentation='Whether the High Water Mark should be turned off. Optional, default False.') -%}
     {%- set source_is_single_batch  = datavault4dbt.yaml_metadata_parser(name='source_is_single_batch', yaml_metadata=yaml_metadata, parameter=source_is_single_batch, required=False, documentation='Whether the source contains only one batch. Optional, default False.') -%}
     {%- set union_strategy =  datavault4dbt.yaml_metadata_parser(name='union_strategy', yaml_metadata=yaml_metadata, parameter=union_strategy, required=False, documentation=union_strategy_description) -%}
+    {%- set additional_columns     = datavault4dbt.yaml_metadata_parser(name='additional_columns', yaml_metadata=yaml_metadata, parameter=additional_columns, required=False, documentation=additional_columns_description) -%}
 
     {# Applying the default aliases as stored inside the global variables, if src_ldts and src_rsrc are not set. #}
 
@@ -120,6 +126,7 @@
                                                         source_models=source_models,
                                                         disable_hwm=disable_hwm,
                                                         source_is_single_batch=source_is_single_batch,
-                                                        union_strategy=union_strategy) -}}
+                                                        union_strategy=union_strategy,
+                                                        additional_columns=additional_columns) -}}
 
 {%- endmacro -%}

--- a/macros/tables/oracle/hub.sql
+++ b/macros/tables/oracle/hub.sql
@@ -1,4 +1,4 @@
-{%- macro oracle__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro oracle__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
@@ -9,6 +9,9 @@
 
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
+
+{# Select the additional_columns values from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -24,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -151,7 +154,8 @@ WITH
             {% endfor -%}
 
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -192,7 +196,8 @@ source_new_union AS (
         {% endfor -%}
 
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/oracle/hub.sql
+++ b/macros/tables/oracle/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -153,9 +153,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,9 +198,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/oracle/link.sql
+++ b/macros/tables/oracle/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/oracle/link.sql
+++ b/macros/tables/oracle/link.sql
@@ -1,4 +1,4 @@
-{%- macro oracle__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro oracle__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -13,6 +13,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -26,7 +29,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -154,7 +157,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -194,7 +198,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/oracle/link.sql
+++ b/macros/tables/oracle/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/oracle/nh_link.sql
+++ b/macros/tables/oracle/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/oracle/nh_link.sql
+++ b/macros/tables/oracle/nh_link.sql
@@ -1,10 +1,13 @@
-{%- macro oracle__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro oracle__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -40,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -169,7 +172,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -215,7 +218,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/postgres/hub.sql
+++ b/macros/tables/postgres/hub.sql
@@ -1,4 +1,4 @@
-{%- macro postgres__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro postgres__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
@@ -9,6 +9,9 @@
 
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
+
+{# Select the additional_columns values from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -24,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -151,7 +154,8 @@ WITH
             {% endfor -%}
 
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -192,7 +196,8 @@ source_new_union AS (
         {% endfor -%}
 
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/postgres/hub.sql
+++ b/macros/tables/postgres/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -153,9 +153,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,9 +198,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/postgres/link.sql
+++ b/macros/tables/postgres/link.sql
@@ -1,5 +1,5 @@
 
-{%- macro postgres__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro postgres__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -14,6 +14,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -27,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -155,7 +158,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,7 +199,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/postgres/link.sql
+++ b/macros/tables/postgres/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/postgres/link.sql
+++ b/macros/tables/postgres/link.sql
@@ -15,7 +15,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -30,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -157,9 +157,14 @@ WITH
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
+        {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -198,9 +203,13 @@ source_new_union AS (
         {% for fk in source_model['fk_columns']|list %}
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/postgres/link.sql
+++ b/macros/tables/postgres/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/postgres/nh_link.sql
+++ b/macros/tables/postgres/nh_link.sql
@@ -1,10 +1,13 @@
-{%- macro postgres__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro postgres__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -40,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -169,7 +172,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -215,7 +218,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/postgres/nh_link.sql
+++ b/macros/tables/postgres/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}

--- a/macros/tables/postgres/nh_link.sql
+++ b/macros/tables/postgres/nh_link.sql
@@ -7,7 +7,7 @@
 {{ log('source_models: '~source_models, false) }}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -43,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -170,9 +170,13 @@ src_new_{{ source_number }} AS (
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -216,9 +220,12 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/redshift/hub.sql
+++ b/macros/tables/redshift/hub.sql
@@ -1,4 +1,4 @@
-{%- macro redshift__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro redshift__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
@@ -9,6 +9,9 @@
 
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
+
+{# Select the additional_columns values from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -24,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -151,7 +154,8 @@ WITH
             {% endfor -%}
 
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -192,7 +196,8 @@ source_new_union AS (
         {% endfor -%}
 
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/redshift/hub.sql
+++ b/macros/tables/redshift/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -153,9 +153,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,9 +198,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/redshift/link.sql
+++ b/macros/tables/redshift/link.sql
@@ -1,5 +1,5 @@
 
-{%- macro redshift__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro redshift__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -14,6 +14,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -27,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -155,7 +158,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,7 +199,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/redshift/link.sql
+++ b/macros/tables/redshift/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/redshift/link.sql
+++ b/macros/tables/redshift/link.sql
@@ -15,7 +15,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -30,7 +30,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -157,9 +157,14 @@ WITH
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
+        {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -198,9 +203,13 @@ source_new_union AS (
         {% for fk in source_model['fk_columns']|list %}
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/redshift/link.sql
+++ b/macros/tables/redshift/link.sql
@@ -14,7 +14,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/redshift/nh_link.sql
+++ b/macros/tables/redshift/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -42,7 +42,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -169,9 +169,13 @@ src_new_{{ source_number }} AS (
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -215,9 +219,12 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/redshift/nh_link.sql
+++ b/macros/tables/redshift/nh_link.sql
@@ -1,9 +1,12 @@
-{%- macro redshift__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro redshift__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -39,7 +42,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -168,7 +171,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -214,7 +217,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/redshift/nh_link.sql
+++ b/macros/tables/redshift/nh_link.sql
@@ -5,7 +5,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}

--- a/macros/tables/snowflake/hub.sql
+++ b/macros/tables/snowflake/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -153,9 +153,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,9 +198,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/snowflake/link.sql
+++ b/macros/tables/snowflake/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/snowflake/link.sql
+++ b/macros/tables/snowflake/link.sql
@@ -1,4 +1,4 @@
-{%- macro snowflake__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro snowflake__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -13,6 +13,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -26,7 +29,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -154,7 +157,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -194,7 +198,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/snowflake/link.sql
+++ b/macros/tables/snowflake/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/snowflake/nh_link.sql
+++ b/macros/tables/snowflake/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/snowflake/nh_link.sql
+++ b/macros/tables/snowflake/nh_link.sql
@@ -7,7 +7,7 @@
 {{ log('source_models: '~source_models, false) }}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -42,7 +42,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -169,9 +169,13 @@ src_new_{{ source_number }} AS (
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -215,9 +219,12 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/snowflake/nh_link.sql
+++ b/macros/tables/snowflake/nh_link.sql
@@ -1,10 +1,13 @@
-{%- macro snowflake__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro snowflake__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {{ log('source_models: '~source_models, false) }}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -39,7 +42,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -168,7 +171,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -214,7 +217,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/synapse/hub.sql
+++ b/macros/tables/synapse/hub.sql
@@ -1,4 +1,4 @@
-{%- macro synapse__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm) -%}
+{%- macro synapse__hub(hashkey, business_keys, src_ldts, src_rsrc, source_models, disable_hwm, additional_columns) -%}
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
@@ -9,6 +9,9 @@
 
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
+
+{# Select the additional_columns values from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -24,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -151,7 +154,8 @@ WITH
             {% endfor -%}
 
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -192,7 +196,8 @@ source_new_union AS (
         {% endfor -%}
 
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/synapse/hub.sql
+++ b/macros/tables/synapse/hub.sql
@@ -10,8 +10,8 @@
 {# Select the Business Key column from the first source model definition provided in the hub model and put them in an array. #}
 {%- set business_keys = datavault4dbt.expand_column_list(columns=[business_keys]) -%}
 
-{# Select the additional_columns values from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{# Select the additional_columns from the hub model and put them in an array. If additional_colums none, then empty array#}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific bk_columns is defined for each source, we apply the values set in the business_keys variable. #}
 {# If no specific hk_column is defined for each source, we apply the values set in the hashkey variable. #}
@@ -27,7 +27,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
+{%- set final_columns_to_select = [hashkey] + business_keys + [src_ldts] + [src_rsrc] + additional_columns  -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -153,9 +153,12 @@ WITH
             {{ bk }} AS {{ business_keys[loop.index - 1] }},
             {% endfor -%}
 
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+
             {{ src_ldts }},
-            {{ src_rsrc }},
-            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+            {{ src_rsrc }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -195,9 +198,12 @@ source_new_union AS (
             {{ business_keys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
-        {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
+        {{ src_rsrc }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/synapse/link.sql
+++ b/macros/tables/synapse/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the extra source columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the hub model and put them in an array. #}
 {%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/synapse/link.sql
+++ b/macros/tables/synapse/link.sql
@@ -1,4 +1,4 @@
-{%- macro synapse__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm) -%}
+{%- macro synapse__link(link_hashkey, foreign_hashkeys, source_models, src_ldts, src_rsrc, disable_hwm, additional_columns) -%}
 
 {%- if not (foreign_hashkeys is iterable and foreign_hashkeys is not string) -%}
 
@@ -13,6 +13,9 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{# Select the extra source columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
 {# For the use of record_source performance lookup it is required that every source model has the parameter rsrc_static defined and it cannot be an empty string #}
@@ -26,7 +29,7 @@
 {%- set ns.source_models_rsrc_dict = source_model_values['source_models_rsrc_dict'] -%}
 {{ log('source_models: '~source_models, false) }}
 
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -154,7 +157,8 @@ WITH
             {{ fk }},
             {% endfor -%}
             {{ src_ldts }},
-            {{ src_rsrc }}
+            {{ src_rsrc }},
+            {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
         FROM {{ ref(source_model.name) }} src
         {{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}
 
@@ -194,7 +198,8 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
         {{ src_ldts }},
-        {{ src_rsrc }}
+        {{ src_rsrc }},
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }}
     FROM src_new_{{ source_number }}
 
     {%- if not loop.last %}

--- a/macros/tables/synapse/link.sql
+++ b/macros/tables/synapse/link.sql
@@ -13,7 +13,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk and fk_columns are defined for each source, we apply the values set in the link_hashkey and foreign_hashkeys variable. #}

--- a/macros/tables/synapse/nh_link.sql
+++ b/macros/tables/synapse/nh_link.sql
@@ -1,10 +1,13 @@
-{%- macro synapse__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy) -%}
+{%- macro synapse__nh_link(link_hashkey, foreign_hashkeys, payload, source_models, src_ldts, src_rsrc, disable_hwm, source_is_single_batch, union_strategy, additional_columns) -%}
 
 {%- set ns = namespace(last_cte= "", source_included_before = {}, has_rsrc_static_defined=true, source_models_rsrc_dict={}) -%}
 
 {%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%} {# not in other adaters#}
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+
+{# Select the additional_columns from the hub model and put them in an array. #}
+{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -40,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -169,7 +172,7 @@ src_new_{{ source_number }} AS (
             {% endfor -%}
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -215,7 +218,7 @@ source_new_union AS (
 
         {{ src_ldts }},
         {{ src_rsrc }},
-
+        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/synapse/nh_link.sql
+++ b/macros/tables/synapse/nh_link.sql
@@ -7,7 +7,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
 {# Select the additional_columns from the hub model and put them in an array. #}
-{%- set additional_columns = datavault4dbt.expand_column_list(columns=[additional_columns]) -%}
+{%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}
 {# If no rsrc_static parameter is defined in ANY of the source models then the whole code block of record_source performance lookup is not executed  #}
@@ -43,7 +43,7 @@
 {%- if not datavault4dbt.is_something(foreign_hashkeys) -%}
     {%- set foreign_hashkeys = [] -%}
 {%- endif -%}
-{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + (additional_columns if additional_columns is not none else []) + payload -%}
+{%- set final_columns_to_select = [link_hashkey] + foreign_hashkeys + [src_ldts] + [src_rsrc] + additional_columns  + payload -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -170,9 +170,13 @@ src_new_{{ source_number }} AS (
             {% for fk in source_model['fk_columns'] -%}
             {{ fk }},
             {% endfor -%}
+
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {{ datavault4dbt.print_list(source_model['payload']) | indent(3) }}
 
     FROM {{ ref(source_model.name) }} src
@@ -216,9 +220,12 @@ source_new_union AS (
             {{ fk }} AS {{ foreign_hashkeys[loop.index - 1] }},
         {% endfor -%}
 
+        {% for col in additional_columns -%}
+            {{ col }},
+        {% endfor -%}
+
         {{ src_ldts }},
         {{ src_rsrc }},
-        {{ datavault4dbt.print_list(additional_columns) | indent(4) }},
         {% for col in source_model['payload']|list %}
             {{ col }} AS {{ payload[loop.index - 1] }}
             {%- if not loop.last %}, {%- endif %}

--- a/macros/tables/synapse/nh_link.sql
+++ b/macros/tables/synapse/nh_link.sql
@@ -6,7 +6,7 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
-{# Select the additional_columns from the hub model and put them in an array. #}
+{# Select the additional_columns from the nh-link model and put them in an array. If additional_colums none, then empty array#}
 {%- set additional_columns = additional_columns | default([],true) -%}
 
 {# If no specific link_hk, fk_columns, or payload are defined for each source, we apply the values set in the link_hashkey, foreign_hashkeys, and payload variable. #}


### PR DESCRIPTION
# Description
@tkiehn & @tkirschke I have actually a custom adaption in my project which covers the needs for https://github.com/ScalefreeCOM/datavault4dbt/issues/343. I think it can be useful to the Project in general so I put a little bit of work into it to bring it to all other Adapters. Feel free to check it out :)

**Whats New?**
With this Pull Request a new Parameter "additional_columns" will be introduced to Hub, Link and NH-Link.
In this new Parameter columns can be defined which will be custom part of the table structure of the according Table to satisfy edge-cases which require additional columns to Hubs & Link structures.

**Why is that useful?**
Especially when it comes to Multi-Tenant or Enterprise Environments it can be required to introduce Tenant-IDs or add BKCCs to the Hashkeys.

- BKCCs: Are currently supported by custom defined Hashkeys but for full transparency it can be helpful to also integrate the BKCC value column to the Table. Actually, there is no possibility to realize that without specify them as BK.
- Tenant IDs: Sometimes its required to have Tenant IDs in the Tables to guarantee Tenant distinction in all requests. To introduce the tenant id as BK is from my perspective not always correct.

Maybe in different Environments there are also other requirements for other Columns to add them in the Tables (Jira IDs, ...). This would be also solved by this parameter.

**Compatibility**
Should be backward compatible due the default-value of the Parameter to 'none'. If the parameter is not set, it is treated accordingly and nothing is selected in the SQL.

**Limitations**
- The columns which are defined in additional_columns Parameter needs to be in all staging-models which are used by this Model. Otherwise, the compilation runs into an Error.
- Its Backward-Compatible but to use this Feature on existing Tables you have to rebuild it.

**Why only Hubs / Links and not Satellites?**
Actually, for the defined Use cases it would only be useful for these Macros. In Satellites there is mostly the possibility to add the columns to the payload without harming the DV-Logic.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Successful Test on Databricks Environment for Hub, Link, Nh-Link by adding two custom columns.

**Test Configuration**:
* datavault4dbt-Version: 1.9.11
* dbt-Version: core, version number: 1.10.10
* dbt-adapter-Version: 1.10.10

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
