### PR TITLE
Add prejoining condition parameter

### DIFF
--- a/macros/internal/metadata_processing/multikey.sql
+++ b/macros/internal/metadata_processing/multikey.sql
@@ -14,6 +14,18 @@
         {%- set columns = [columns] -%}
     {%- endif -%}
 
+    {%- if condition is string -%}
+        {%- set condition = [condition] -%}
+    {%- elif condition|length != columns|length -%}
+        {%- set error_message -%}
+      Multikey Error: If condition are defined, it must be the same length as columns. 
+      Got: 
+        Columns: {{ columns }} with length {{ columns|length }}
+        condition: {{ condition }} with length {{ condition|length }}
+        {%- endset -%}
+        {{- exceptions.raise_compiler_error(error_message) -}}
+    {%- endif -%}
+
     {%- if right_columns is none -%}
         {%- set right_columns = columns -%}
     {%- elif right_columns is string -%}
@@ -29,17 +41,19 @@
         {{- exceptions.raise_compiler_error(error_message) -}}
     {%- endif -%}
 
-    {%- if condition in ['<>', '!=', '=', '<=', '>=', '<', '>'] -%}
+    {%- if condition | reject("in", ['<>', '!=', '=', '<=', '>=', '<', '>']) | list | length == 0 -%}
+        {%- set is_single_condition = condition | length == 1 -%}
         {%- for col in columns -%}
             {%- if prefix -%}
-                {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition }} {{ datavault4dbt.prefix([right_columns[loop.index0]], prefix[1]) -}}
+                {%- set condition_item = condition[0] if is_single_condition else condition[loop.index0] %}
+                {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition_item }} {{ datavault4dbt.prefix([right_columns[loop.index0]], prefix[1]) -}}
             {%- endif %}
             {%- if not loop.last %} {{ operator }} {% endif -%}
         {% endfor -%}
     {%- else -%}
         {%- if datavault4dbt.is_list(columns) -%}
             {%- for col in columns -%}
-                {{ (prefix[0] ~ '.') if prefix }}{{ col }} {{ condition if condition else '' }}
+                {{ (prefix[0] ~ '.') if prefix }}{{ col }} {{ condition[loop.index0] if condition else '' }}
                 {%- if not loop.last -%} {{ "\n    " ~ operator }} {% endif -%}
             {%- endfor -%}
         {%- else -%}

--- a/macros/internal/metadata_processing/multikey.sql
+++ b/macros/internal/metadata_processing/multikey.sql
@@ -29,7 +29,7 @@
         {{- exceptions.raise_compiler_error(error_message) -}}
     {%- endif -%}
 
-    {%- if condition in ['<>', '!=', '='] -%}
+    {%- if condition in ['<>', '!=', '=', '<=', '>=', '<', '>'] -%}
         {%- for col in columns -%}
             {%- if prefix -%}
                 {{- datavault4dbt.prefix([col], prefix[0], alias_target='target') }} {{ condition }} {{ datavault4dbt.prefix([right_columns[loop.index0]], prefix[1]) -}}

--- a/macros/staging/databricks/stage.sql
+++ b/macros/staging/databricks/stage.sql
@@ -335,20 +335,30 @@ prejoined_columns AS (
     {%- else -%}
       {%- set operator = prejoin['operator'] -%}
     {%- endif -%}
+
     {%- if 'join_type' not in prejoin.keys() -%}
       {%- set join_type = 'left' -%}
     {%- else -%}
-      {%- set join_type = prejoin['join_type'] -%}
+      {%- set join_type = join_type -%}
     {%- endif -%}
-    {%- if 'condition' not in prejoin.keys() -%}
+
+    {%- if 'condition' not in prejoin.keys()-%}
       {%- set condition = '=' -%}
+    {%- elif prejoin['condition'] | reject("in", ['<>', '!=', '=', '<=', '>=', '<', '>']) | list | length > 0 -%}
+      {%- set error_message -%}
+          Value Error: One of the defined conditions is not supported
+          Got: 
+              condition: {{ prejoin['condition'] }}
+      {%- endset -%}
+      {{- exceptions.raise_compiler_error(error_message) -}}
     {%- else -%}
       {%- set condition = prejoin['condition'] -%}
     {%- endif -%}
-      {%- set prejoin_alias = 'pj_' + loop.index|string %}
+
+    {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
-      {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
-        on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition=condition, operator=operator, right_columns=prejoin['ref_column_name']) }}
+    {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
+      on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition=condition, operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 
   {% set last_cte = "prejoined_columns" -%}

--- a/macros/staging/databricks/stage.sql
+++ b/macros/staging/databricks/stage.sql
@@ -340,10 +340,15 @@ prejoined_columns AS (
     {%- else -%}
       {%- set join_type = prejoin['join_type'] -%}
     {%- endif -%}
+    {%- if 'condition' not in prejoin.keys() -%}
+      {%- set condition = '=' -%}
+    {%- else -%}
+      {%- set condition = prejoin['condition'] -%}
+    {%- endif -%}
       {%- set prejoin_alias = 'pj_' + loop.index|string %}
       
       {{ join_type }} join {{ relation }} as {{ prejoin_alias }}
-        on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition='=', operator=operator, right_columns=prejoin['ref_column_name']) }}
+        on {{ datavault4dbt.multikey(columns=prejoin['this_column_name'], prefix=['lcte', prejoin_alias], condition=condition, operator=operator, right_columns=prejoin['ref_column_name']) }}
   {%- endfor -%}
 
   {% set last_cte = "prejoined_columns" -%}

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -243,6 +243,11 @@
                             {%- set join_type = 'left' -%}
                         {%- else -%}
             {%- set join_type = value.get('join_type') -%}
+            {%- if 'condition' not in value.keys() -%}  
+                            {%- do value.update({'condition': '='}) -%}
+                            {%- set condition = '=' -%}
+                        {%- else -%}
+            {%- set condition = value.get('condition') -%}
             {%- endif -%}
                         
     {% set match_criteria = (
@@ -252,6 +257,7 @@
         | selectattr('ref_column_name', 'equalto', value.ref_column_name)
         | selectattr('operator', 'equalto', value.operator)
         | selectattr('join_type', 'equalto', value.join_type)
+        | selectattr('condition', 'equalto', value.condition)
         | list | first %}
         
             {% if match_criteria %}
@@ -264,7 +270,8 @@
                     'this_column_name': value.this_column_name,
                     'ref_column_name': value.ref_column_name,
                     'operator': operator,
-                    'join_type': join_type
+                    'join_type': join_type,
+                    'condition': condition
                 } %}            
                 
                 {% if ref_model %}

--- a/macros/staging/stage_processing_macros.sql
+++ b/macros/staging/stage_processing_macros.sql
@@ -243,6 +243,7 @@
                             {%- set join_type = 'left' -%}
                         {%- else -%}
             {%- set join_type = value.get('join_type') -%}
+            {%- endif -%}
             {%- if 'condition' not in value.keys() -%}  
                             {%- do value.update({'condition': '='}) -%}
                             {%- set condition = '=' -%}


### PR DESCRIPTION
# Description
This PR handles issue #370. A new Parameter "condition" is introduced to Prejoining which allows to define a custom condition for each Join.

@tkiehn @tkirschke Hope its helpful for the Package in general, feel free to review it and give me Feedback :)
Actually only in Staging-Template for databricks. But would be the same pattern. Open to apply it as well to all other platforms when general approach is approved.

Parameter Description:

**Key**: condition (optional)
**DataType**: string | list
**Explanation**: Can be used optionally to define custom join conditions. If a single condition is defined as string it will apply the condition to all joins. If multiple conditions are defined it will be applied in the according order. The Default condition will be '='. Supported conditions: ['<>', '!=', '=', '<=', '>=', '<', '>']. The Condition Parameter should be quoted in the Template.

### Condition-Examples:
```
prejoined_columns:
    - extract_columns: 
         - account_id
      aliases:
         - acc_id
      ref_model: account_sap
      this_column_name: 
        - acc_code
        - active_date
        - active_date
      ref_column_name: 
        - account_kuerzel
        - acc_valid_from
        - acc_valid_to
      condition:
        - '='
        - '>='
        - '<='
```
=> Will lead to 3 Joins with: acc_code = account_kuerzel and active_date >= acc_valid_from and active_date <= acc_valid_to

```
prejoined_columns:
    - extract_columns: 
         - account_id
      aliases:
         - acc_id
      ref_model: account_sap
      this_column_name: 
        - acc_code
      ref_column_name: 
        - account_kuerzel
```
=> Will lead to normal Join with: acc_code = account_kuerzel

```
prejoined_columns:
    - extract_columns: 
         - account_id
      aliases:
         - acc_id
      ref_model: account_sap
      this_column_name: 
        - acc_code
        - name
      ref_column_name: 
        - account_kuerzel
        - name_lang
     condition: '!='
```
=> Lead that all joins using the defined condition: acc_code != account_kuerzel and name != name_lang

### Tests & Allowed Values
The following Tests are implemented and results in error if not fulfilled:
- The length of conditions (if list) needs to be identical with the length of source_columns
- The allowed conditions are ['<>', '!=', '=', '<=', '>=', '<', '>']

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Test a Staging config without condition Parameter to guarantee Backward Compatability
- [x] Test a Staging config with a single condition (string)
- [x] Test a Staging config with multiple conditions (list)
- [x] Test a Staging config with invalid conditions or non-matching length of conditions with source_columns

**Test Configuration**:
* datavault4dbt-Version: 1.10.0
* dbt-Version: core, version number: 1.10.11
* dbt-adapter-Version: 1.10.12

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
