### PR TITLE
Refactor Redshift Eff. Sat SQL to use LEFT JOIN instead of WHERE NOT EXISTS for incremental logic

### DIFF
--- a/macros/tables/redshift/eff_sat_v0.sql
+++ b/macros/tables/redshift/eff_sat_v0.sql
@@ -291,19 +291,17 @@ records_to_insert AS (
 )
 
 SELECT 
-    {{ tracked_hashkey }},
-    {{ src_ldts }},
-    {{ src_rsrc }},
-    cast({{ is_active_alias }} as {{ is_active_datatype }}) as {{ is_active_alias }}
+    ri.{{ tracked_hashkey }},
+    ri.{{ src_ldts }},
+    ri.{{ src_rsrc }},
+    cast(ri.{{ is_active_alias }} as {{ is_active_datatype }}) as {{ is_active_alias }}
 FROM records_to_insert ri
 
 {% if is_incremental() %}
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM {{ this }} t
-    WHERE t.{{ tracked_hashkey }} = ri.{{ tracked_hashkey }}
-        AND t.{{ src_ldts }} = ri.{{ src_ldts }}
-)
+LEFT JOIN {{ this }} t
+    ON t.{{ tracked_hashkey }} = ri.{{ tracked_hashkey }}
+    AND t.{{ src_ldts }} = ri.{{ src_ldts }}
+WHERE t.{{ tracked_hashkey }} IS NULL
 {% endif %}
 
 {%- endmacro -%}


### PR DESCRIPTION


# Description

The WHERE NOT EXISTS was throwing an Error in my redshift instance. Changing it to a left join fixed it for me. 

Error was "this type of correlated subquery pattern is not supported".

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Tests you ran

**Test Configuration**:
* datavault4dbt-Version: 1.12.3
* dbt-Version: _cloud/core, version number_: dbt core 1.10.10
* dbt-adapter-Version: redshift 1.9.5

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
