### PR TITLE
280 - Making Payload in Satellites and Reference Satellites optional

### DIFF
--- a/docs/01_macro-instructions/10_satellites/10_standard-satellites/10_standard-satellite-v0.md
+++ b/docs/01_macro-instructions/10_satellites/10_standard-satellites/10_standard-satellite-v0.md
@@ -20,14 +20,14 @@ Features:
 | Parameters      | Data Type       | Required  | Default Value | Explanation |
 |-----------------|----------------|-----------|---------------|-------------|
 | parent_hashkey | string         | mandatory | –             | Name of the hashkey column inside the stage of the object that this satellite is attached to. |
-| src_hashdiff   | string         | mandatory | –             | Name of the hashdiff column of this satellite, that was created inside the staging area and is calculated out of the entire payload of this satellite. The stage must hold one hashdiff per satellite entity. |
-| src_payload    | list of strings| mandatory | –             | A list of all the descriptive attributes that should be included in this satellite. Needs to be the columns that are fed into the hashdiff calculation of this satellite. |
 | source_model   | string         | mandatory | –             | Name of the underlying staging model, must be available inside dbt as a model. |
 
 ### OPTIONAL PARAMETERS
 
 | Parameters             | Data Type | Required | Default Value             | Explanation |
 |------------------------|----------|----------|---------------------------|-------------|
+| src_payload            | list of strings | optional | none               | The descriptive attributes that should be included in this satellite. With a single column, `src_hashdiff` may be omitted and change detection runs directly on that column. With two or more columns, `src_hashdiff` is required. Omit entirely for a satellite without payload. See [Payload and hashdiff options](#payload-and-hashdiff-options). |
+| src_hashdiff           | string   | optional | none                      | Name of the hashdiff column of this satellite, that was created inside the staging area and is calculated out of the entire payload of this satellite. The stage must hold one hashdiff per satellite entity. Required when `src_payload` has two or more columns; omit it for a single-attribute or no-payload satellite. |
 | src_ldts               | string   | optional | datavault4dbt.ldts_alias  | Name of the ldts column inside the source model. Is optional, will use the global variable `datavault4dbt.ldts_alias`. Needs to use the same column name as defined as alias inside the staging model. |
 | src_rsrc               | string   | optional | datavault4dbt.rsrc_alias  | Name of the rsrc column inside the source model. Is optional, will use the global variable `datavault4dbt.rsrc_alias`. Needs to use the same column name as defined as alias inside the staging model. |
 | disable_hwm            | boolean  | optional | False                     | Whether the automatic application of a High-Water Mark (HWM) should be disabled or not. |
@@ -64,3 +64,45 @@ With this example, a regular standard Satellite in version 0 is created. Importa
 - **src_payload**: This satellite would hold the columns `name`, `address`, `phone` and `email`, coming out of the underlying staging area.
 - **source_models**:
   - __stage_account__: This satellite is loaded out of the stage for account.
+
+## PAYLOAD AND HASHDIFF OPTIONS
+
+Both `src_payload` and `src_hashdiff` are optional. Depending on what you provide, a standard satellite supports three configurations:
+
+1. **Multiple attributes with a hashdiff** — provide `src_payload` (one or more columns) together with `src_hashdiff`. Change detection runs on the hashdiff. *Use this when the satellite carries several descriptive attributes — the classic case shown in Example 1 above.*
+2. **A single attribute without a hashdiff** — provide exactly one `src_payload` column and omit `src_hashdiff`. Change detection runs directly on that column. *Use this when the satellite tracks exactly one descriptive attribute (for example a status or a flag); it avoids computing and storing a hashdiff.*
+3. **No payload** — omit both `src_payload` and `src_hashdiff`. The satellite only records when a hashkey appears, together with the load date, record source and any `additional_columns`. *Use this when you only need to record that (and when) a business key appeared, or for a satellite that carries only `additional_columns`.*
+
+If `src_payload` contains two or more columns but `src_hashdiff` is missing, compilation fails with a clear error, since a hashdiff is required to detect changes across multiple columns.
+
+### EXAMPLE 2 – single attribute without a hashdiff
+
+```jinja
+{{ config(materialized='incremental') }}
+
+{%- set yaml_metadata -%}
+parent_hashkey: 'hk_account_h'
+src_payload:
+    - account_status
+source_model: 'stage_account'
+{%- endset -%}    
+
+{{ datavault4dbt.sat_v0(yaml_metadata=yaml_metadata) }}
+```
+
+Change detection runs directly on `account_status`; a new record is inserted whenever its value changes for a hashkey.
+
+### EXAMPLE 3 – no payload
+
+```jinja
+{{ config(materialized='incremental') }}
+
+{%- set yaml_metadata -%}
+parent_hashkey: 'hk_account_h'
+source_model: 'stage_account'
+{%- endset -%}    
+
+{{ datavault4dbt.sat_v0(yaml_metadata=yaml_metadata) }}
+```
+
+The satellite records each hashkey together with its load date and record source. A new record is only inserted when a hashkey appears that is not yet present. If your goal is purely to track the appearance of a key across one or more source systems, also consider the dedicated [Record-Tracking Satellite](../15_record-tracking-satellites/15_record-tracking-satellites.md).

--- a/docs/01_macro-instructions/10_satellites/10_standard-satellites/11_standard-satellite-v1.md
+++ b/docs/01_macro-instructions/10_satellites/10_standard-satellites/11_standard-satellite-v1.md
@@ -21,12 +21,12 @@ Features:
 |------------|-----------|-----------|---------------|-------------|
 | sat_v0     | string    | mandatory | –             | Name of the underlying version 0 satellite. |
 | hashkey    | string    | mandatory | –             | Name of the parent hashkey column inside the version 0 satellite. Would either be the hashkey of a hub or a link. Needs to be similar to the `parent_hashkey` parameter inside the sat_v0 model. |
-| hashdiff   | string    | mandatory | –             | Name of the hashdiff column inside the underlying version 0 satellite. Needs to be similar to the `src_hashdiff` parameter inside the sat_v0 model. |
 
 ### OPTIONAL PARAMETERS
 
 | Parameters          | Data Type | Required | Default Value              | Explanation |
 |---------------------|-----------|----------|----------------------------|-------------|
+| hashdiff            | string    | optional | none                       | Name of the hashdiff column inside the underlying version 0 satellite. Needs to be similar to the `src_hashdiff` parameter inside the sat_v0 model. Set this only if the underlying v0 satellite has a hashdiff column; omit it for a single-attribute or no-payload v0 satellite. |
 | src_ldts            | string    | optional | datavault4dbt.ldts_alias   | Name of the ldts column inside the source models. Needs to use the same column name as defined as alias inside the staging model. |
 | src_rsrc            | string    | optional | datavault4dbt.rsrc_alias   | Name of the rsrc column inside the source models. Needs to use the same column name as defined as alias inside the staging model. |
 | ledts_alias         | string    | optional | datavault4dbt.ledts_alias  | Desired alias for the load end date column. |

--- a/docs/01_macro-instructions/17_reference-data/19_reference-satellite/19_reference-satellite-v0.md
+++ b/docs/01_macro-instructions/17_reference-data/19_reference-satellite/19_reference-satellite-v0.md
@@ -22,14 +22,14 @@ Besides that, a reference Satellite v0 shares the same features as a regular Sat
 | Parameters      | Data Type        | Required  | Default Value | Explanation |
 |-----------------|------------------|-----------|---------------|-------------|
 | parent_ref_keys | string \| list   | mandatory | –             | Name of the reference key(s) inside the parent reference Hub. |
-| src_hashdiff    | string           | mandatory | –             | Name of the hashdiff column of this satellite, that was created inside the staging area and is calculated out of the entire payload of this satellite. The stage must hold one hashdiff per satellite entity. |
-| src_payload     | list of strings  | mandatory | –             | A list of all the descriptive attributes that should be included in this satellite. Needs to be the columns that are fed into the hashdiff calculation of this satellite. |
 | source_model    | string           | mandatory | –             | Name of the underlying staging model, must be available inside dbt as a model. |
 
 ### OPTIONAL PARAMETERS
 
 | Parameters  | Data Type | Required | Default Value              | Explanation |
 |-------------|-----------|----------|----------------------------|-------------|
+| src_payload | list of strings | optional | none                 | The descriptive attributes that should be included in this reference satellite. With a single column, `src_hashdiff` may be omitted and change detection runs directly on that column. With two or more columns, `src_hashdiff` is required. Omit entirely for a reference satellite without payload. See [Payload and hashdiff options](#payload-and-hashdiff-options). |
+| src_hashdiff | string   | optional | none                       | Name of the hashdiff column of this satellite, that was created inside the staging area and is calculated out of the entire payload of this satellite. The stage must hold one hashdiff per satellite entity. Required when `src_payload` has two or more columns; omit it for a single-attribute or no-payload reference satellite. |
 | src_ldts    | string    | optional | datavault4dbt.ldts_alias   | Name of the ldts column inside the source model. Needs to use the same column name as defined as alias inside the staging model. |
 | src_rsrc    | string    | optional | datavault4dbt.rsrc_alias   | Name of the rsrc column inside the source model. Is optional, will use the global variable `datavault4dbt.rsrc_alias`. Needs to use the same column name as defined as alias inside the staging model. |
 | disable_hwm | boolean   | optional | False                      | Whether the automatic application of a High-Water Mark (HWM) should be disabled or not. |
@@ -134,3 +134,43 @@ records_to_insert AS (
 SELECT * FROM records_to_insert
 ```
 </details>
+
+## PAYLOAD AND HASHDIFF OPTIONS
+
+Both `src_payload` and `src_hashdiff` are optional. Depending on what you provide, a reference satellite supports three configurations:
+
+1. **Multiple attributes with a hashdiff** — provide `src_payload` (one or more columns) together with `src_hashdiff`. Change detection runs on the hashdiff. *Use this when the reference satellite carries several descriptive attributes — the classic case shown in Example 1 above.*
+2. **A single attribute without a hashdiff** — provide exactly one `src_payload` column and omit `src_hashdiff`. Change detection runs directly on that column. *Use this when the reference satellite tracks exactly one descriptive attribute; it avoids computing and storing a hashdiff.*
+3. **No payload** — omit both `src_payload` and `src_hashdiff`. The reference satellite only records when a reference key appears, together with the load date, record source and any `additional_columns`.
+
+If `src_payload` contains two or more columns but `src_hashdiff` is missing, compilation fails with a clear error, since a hashdiff is required to detect changes across multiple columns.
+
+### EXAMPLE 2 – single attribute without a hashdiff
+
+```jinja
+{{ config(materialized='incremental',
+        schema='Core') }}
+
+{%- set yaml_metadata -%}
+source_model: stg_nation
+parent_ref_keys: N_NATIONKEY
+src_payload:
+    - N_NAME
+{%- endset -%}      
+
+{{ datavault4dbt.ref_sat_v0(yaml_metadata=yaml_metadata) }}
+```
+
+### EXAMPLE 3 – no payload
+
+```jinja
+{{ config(materialized='incremental',
+        schema='Core') }}
+
+{%- set yaml_metadata -%}
+source_model: stg_nation
+parent_ref_keys: N_NATIONKEY
+{%- endset -%}      
+
+{{ datavault4dbt.ref_sat_v0(yaml_metadata=yaml_metadata) }}
+```

--- a/docs/01_macro-instructions/17_reference-data/19_reference-satellite/20_reference-satellite-v1.md
+++ b/docs/01_macro-instructions/17_reference-data/19_reference-satellite/20_reference-satellite-v1.md
@@ -21,12 +21,12 @@ Compared to a regular version 1 Satellite, a version 1 reference Satellite inclu
 |-------------|-------------|-----------|---------------|-------------|
 | ref_sat_v0  | string      | mandatory | –             | Name of the underlying version 0 reference_satellite. |
 | ref_keys    | string/list | mandatory | –             | Name of the reference key(s) inside the parent reference Hub. Should be the same as defined in the underlying version 0 reference Satellite. |
-| hashdiff    | string      | mandatory | –             | Name of the hashdiff column inside the underlying version 0 reference satellite. Needs to be similar to the `src_hashdiff` parameter inside the sat_v0 model. |
 
 ### OPTIONAL PARAMETERS
 
 | Parameters          | Data Type | Required | Default Value              | Explanation |
 |---------------------|-----------|----------|----------------------------|-------------|
+| hashdiff            | string    | optional | none                       | Name of the hashdiff column inside the underlying version 0 reference satellite. Needs to be similar to the `src_hashdiff` parameter inside the ref_sat_v0 model. Set this only if the underlying v0 reference satellite has a hashdiff column; omit it for a single-attribute or no-payload v0 reference satellite. |
 | src_ldts            | string    | optional | datavault4dbt.ldts_alias   | Name of the ldts column inside the source models. Needs to use the same column name as defined as alias inside the staging model. |
 | src_rsrc            | string    | optional | datavault4dbt.rsrc_alias   | Name of the rsrc column inside the source models. Needs to use the same column name as defined as alias inside the staging model. |
 | ledts_alias         | string    | optional | datavault4dbt.ledts_alias  | Desired alias for the load end date column. |

--- a/macros/tables/bigquery/ref_sat_v0.sql
+++ b/macros/tables/bigquery/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +42,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -53,18 +62,20 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
@@ -73,7 +84,9 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
@@ -81,10 +94,12 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -96,19 +111,25 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
+            {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/bigquery/ref_sat_v0.sql
+++ b/macros/tables/bigquery/ref_sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/bigquery/ref_sat_v0.sql
+++ b/macros/tables/bigquery/ref_sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 
@@ -75,7 +72,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -101,7 +98,6 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#

--- a/macros/tables/bigquery/ref_sat_v0.sql
+++ b/macros/tables/bigquery/ref_sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/bigquery/ref_sat_v1.sql
+++ b/macros/tables/bigquery/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,7 +28,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -38,7 +43,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/bigquery/ref_sat_v1.sql
+++ b/macros/tables/bigquery/ref_sat_v1.sql
@@ -33,8 +33,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -48,14 +50,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/bigquery/sat_v0.sql
+++ b/macros/tables/bigquery/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -31,7 +40,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -49,27 +60,35 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
+
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
+{%- if payload_count > 0 %}
 deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
@@ -77,10 +96,11 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -90,16 +110,22 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
-        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %}
+        {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/bigquery/sat_v0.sql
+++ b/macros/tables/bigquery/sat_v0.sql
@@ -52,6 +52,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/bigquery/sat_v0.sql
+++ b/macros/tables/bigquery/sat_v0.sql
@@ -52,7 +52,6 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/bigquery/sat_v1.sql
+++ b/macros/tables/bigquery/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/databricks/ref_sat_v0.sql
+++ b/macros/tables/databricks/ref_sat_v0.sql
@@ -64,6 +64,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/databricks/ref_sat_v0.sql
+++ b/macros/tables/databricks/ref_sat_v0.sql
@@ -33,8 +33,8 @@
 
 {%- set ref_key = datavault4dbt.escape_column_names(ref_key) -%}
 {%- if has_hashdiff -%}
-{%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
-{%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
+    {%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
+    {%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
 {%- endif -%}
 {%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
@@ -58,15 +58,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 
@@ -85,7 +82,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -111,7 +108,6 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#

--- a/macros/tables/databricks/ref_sat_v0.sql
+++ b/macros/tables/databricks/ref_sat_v0.sql
@@ -7,16 +7,21 @@
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 {%- set parent_ref_keys = datavault4dbt.escape_column_names(parent_ref_keys) -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
-
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
-
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -27,11 +32,14 @@
 {%- set source_relation = ref(source_model) -%}
 
 {%- set ref_key = datavault4dbt.escape_column_names(ref_key) -%}
+{%- if has_hashdiff -%}
 {%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
 {%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
+{%- endif -%}
 {%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (datavault4dbt.escape_column_names(src_payload[0]) if payload_count == 1 else none) -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -44,7 +52,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -62,18 +72,20 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
@@ -82,7 +94,9 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
@@ -90,10 +104,12 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -105,19 +121,25 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
+            {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/databricks/ref_sat_v0.sql
+++ b/macros/tables/databricks/ref_sat_v0.sql
@@ -58,13 +58,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/databricks/ref_sat_v1.sql
+++ b/macros/tables/databricks/ref_sat_v1.sql
@@ -8,16 +8,21 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
 {%- set source_columns_to_select = datavault4dbt.escape_column_names(source_columns_to_select) -%}
 {%- set ref_keys = datavault4dbt.escape_column_names(ref_keys) -%}
+{%- if has_hashdiff -%}
 {%- set hashdiff = datavault4dbt.escape_column_names(hashdiff) -%}
+{%- endif -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
@@ -33,7 +38,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -46,7 +53,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/databricks/ref_sat_v1.sql
+++ b/macros/tables/databricks/ref_sat_v1.sql
@@ -43,8 +43,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -58,14 +60,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/databricks/sat_v0.sql
+++ b/macros/tables/databricks/sat_v0.sql
@@ -35,7 +35,7 @@
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) -%}
 {%- if has_hashdiff -%}
-{%- set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) -%}
+    {%- set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) -%}
 {%- endif -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
@@ -59,7 +59,6 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/databricks/sat_v0.sql
+++ b/macros/tables/databricks/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -25,7 +34,9 @@
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) -%}
+{%- if has_hashdiff -%}
 {%- set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) -%}
+{%- endif -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -36,7 +47,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -54,27 +67,35 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
     WHERE 1=1
-    
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
+
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
+{%- if payload_count > 0 %}
 deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
@@ -82,10 +103,11 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -95,16 +117,22 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
-        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %}
+        {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/databricks/sat_v0.sql
+++ b/macros/tables/databricks/sat_v0.sql
@@ -59,6 +59,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/databricks/sat_v1.sql
+++ b/macros/tables/databricks/sat_v1.sql
@@ -8,8 +8,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 {%- set source_columns_to_select = datavault4dbt.escape_column_names(source_columns_to_select) -%}
@@ -18,7 +21,9 @@
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
 {%- set hashkey = datavault4dbt.escape_column_names(hashkey) -%}
+{%- if has_hashdiff -%}
 {%- set hashdiff = datavault4dbt.escape_column_names(hashdiff) -%}
+{%- endif -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -29,7 +34,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
@@ -42,7 +49,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/exasol/ref_sat_v0.sql
+++ b/macros/tables/exasol/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +42,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -53,18 +62,20 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
@@ -73,7 +84,9 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
@@ -81,10 +94,12 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -96,19 +111,25 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
+            {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/exasol/ref_sat_v0.sql
+++ b/macros/tables/exasol/ref_sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/exasol/ref_sat_v0.sql
+++ b/macros/tables/exasol/ref_sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 
@@ -75,7 +72,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -101,7 +98,6 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#

--- a/macros/tables/exasol/ref_sat_v0.sql
+++ b/macros/tables/exasol/ref_sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/exasol/ref_sat_v1.sql
+++ b/macros/tables/exasol/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,7 +28,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -38,7 +43,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/exasol/ref_sat_v1.sql
+++ b/macros/tables/exasol/ref_sat_v1.sql
@@ -33,8 +33,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -48,14 +50,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/exasol/sat_v0.sql
+++ b/macros/tables/exasol/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -31,7 +40,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -49,27 +60,35 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
+
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
+{%- if payload_count > 0 %}
 deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
      , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
@@ -77,10 +96,11 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -90,16 +110,22 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
-        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %}
+        {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/exasol/sat_v0.sql
+++ b/macros/tables/exasol/sat_v0.sql
@@ -52,6 +52,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/exasol/sat_v0.sql
+++ b/macros/tables/exasol/sat_v0.sql
@@ -52,7 +52,6 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/exasol/sat_v1.sql
+++ b/macros/tables/exasol/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) as {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/fabric/ref_sat_v0.sql
+++ b/macros/tables/fabric/ref_sat_v0.sql
@@ -7,14 +7,20 @@
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 {%- set parent_ref_keys = datavault4dbt.escape_column_names(parent_ref_keys) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
@@ -26,10 +32,14 @@
 {%- set source_relation = ref(source_model) -%}
 
 {%- set ref_key = datavault4dbt.escape_column_names(ref_key) -%}
+{%- if has_hashdiff -%}
 {%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
 {%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
+{%- endif -%}
 {%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (datavault4dbt.escape_column_names(src_payload[0]) if payload_count == 1 else none) -%}
 
 WITH
 
@@ -42,7 +52,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ ref_key }},
         {%- endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -54,7 +66,7 @@ source_data AS (
     )
     AND {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
-    
+
     {%- set source_cte = 'source_data' -%}
 
     -- UNION ALL ghost record 000000
@@ -65,12 +77,12 @@ source_data AS (
 target_data AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ ref_key }},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
         , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ ref_key }} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) AS rn
-    FROM 
+    FROM
         {{ this }}
 ),
 {%- endif %}
@@ -80,20 +92,20 @@ target_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ ref_key }},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         target_data
     WHERE rn = 1
 ),
 {%- endif %}
 
-{%- if not source_is_single_batch %}
+{%- if not source_is_single_batch and payload_count > 0 %}
 
 {#
-    Adding hashdiff of the previous record, for each parent ref key combination.
+    Adding dedup column of the previous record, for each parent ref key combination.
 #}
 numbered_source AS (
 
@@ -101,14 +113,16 @@ numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ ref_key }},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) prev_dedup_col
     FROM source_data
 ),
 
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
@@ -117,13 +131,15 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ ref_key }},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ ref_key }} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
     FROM numbered_source
-    WHERE {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+    WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 
@@ -141,7 +157,9 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ ref_key }},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_cte }} sc
     {%- if is_incremental() %}
@@ -152,8 +170,10 @@ records_to_insert AS (
             {% for ref_key in parent_ref_keys %}
             AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
-            {%- if not source_is_single_batch %}
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
+            {%- endif %}
+            {%- if not source_is_single_batch and payload_count > 0 %}
             AND sc.rn = 1
             {%- endif %}
             )

--- a/macros/tables/fabric/ref_sat_v0.sql
+++ b/macros/tables/fabric/ref_sat_v0.sql
@@ -33,8 +33,8 @@
 
 {%- set ref_key = datavault4dbt.escape_column_names(ref_key) -%}
 {%- if has_hashdiff -%}
-{%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
-{%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
+    {%- set ns.src_hashdiff = datavault4dbt.escape_column_names(ns.src_hashdiff) -%}
+    {%- set ns.hdiff_alias = datavault4dbt.escape_column_names(ns.hdiff_alias) -%}
 {%- endif -%}
 {%- set source_cols = datavault4dbt.escape_column_names(source_cols) -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
@@ -58,15 +58,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/fabric/ref_sat_v0.sql
+++ b/macros/tables/fabric/ref_sat_v0.sql
@@ -58,13 +58,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental()  and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/fabric/ref_sat_v1.sql
+++ b/macros/tables/fabric/ref_sat_v1.sql
@@ -8,16 +8,21 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
 {%- set source_columns_to_select = datavault4dbt.escape_column_names(source_columns_to_select) -%}
 {%- set ref_keys = datavault4dbt.escape_column_names(ref_keys) -%}
+{%- if has_hashdiff -%}
 {%- set hashdiff = datavault4dbt.escape_column_names(hashdiff) -%}
+{%- endif -%}
 {%- set src_ldts = datavault4dbt.escape_column_names(src_ldts) -%}
 {%- set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) -%}
 {%- set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) -%}
@@ -33,7 +38,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }},
@@ -46,7 +53,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/fabric/ref_sat_v1.sql
+++ b/macros/tables/fabric/ref_sat_v1.sql
@@ -43,8 +43,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }},
+        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -58,14 +60,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN 1
         ELSE 0
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/fabric/sat_v0.sql
+++ b/macros/tables/fabric/sat_v0.sql
@@ -35,7 +35,7 @@
 {% set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) %}
 {% set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) %}
 {%- if has_hashdiff -%}
-{% set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) %}
+    {%- set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) -%}
 {%- endif -%}
 
 WITH
@@ -53,15 +53,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/fabric/sat_v0.sql
+++ b/macros/tables/fabric/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -25,7 +34,9 @@
 {% set src_ldts = datavault4dbt.escape_column_names(src_ldts) %}
 {% set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) %}
 {% set parent_hashkey = datavault4dbt.escape_column_names(parent_hashkey) %}
+{%- if has_hashdiff -%}
 {% set src_hashdiff = datavault4dbt.escape_column_names(src_hashdiff) %}
+{%- endif -%}
 
 WITH
 
@@ -36,7 +47,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -66,13 +79,15 @@ latest_entries_in_sat_prep AS (
 
     SELECT
         tgt.{{ parent_hashkey }},
-        tgt.{{ ns.hdiff_alias }},
+        {%- if dedup_column is not none %}
+        tgt.{{ dedup_column }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY tgt.{{ parent_hashkey }} ORDER BY tgt.{{ src_ldts }} DESC) as rn
     FROM {{ this }} tgt
     INNER JOIN distinct_incoming_hashkeys src
         ON tgt.{{ parent_hashkey }} = src.{{ parent_hashkey }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
 ),
@@ -80,26 +95,31 @@ latest_entries_in_sat_prep AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
-{%- if not source_is_single_batch %}
+{%- if not source_is_single_batch and payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
 deduplicated_numbered_source_prep AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 
 ),
@@ -108,14 +128,16 @@ deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 
@@ -131,7 +153,9 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_cte }} sc
     {%- if is_incremental() %}
@@ -139,8 +163,10 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
-            {%- if not source_is_single_batch %}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
+        {%- endif %}
+            {%- if not source_is_single_batch and payload_count > 0 %}
             AND sc.rn = 1
             {%- endif %}
     )

--- a/macros/tables/fabric/sat_v0.sql
+++ b/macros/tables/fabric/sat_v0.sql
@@ -53,13 +53,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/fabric/sat_v0.sql
+++ b/macros/tables/fabric/sat_v0.sql
@@ -59,6 +59,7 @@ source_data AS (
             COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/fabric/sat_v1.sql
+++ b/macros/tables/fabric/sat_v1.sql
@@ -8,8 +8,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -19,7 +22,9 @@
 {% set src_rsrc = datavault4dbt.escape_column_names(src_rsrc) %}
 {% set ledts_alias = datavault4dbt.escape_column_names(ledts_alias) %}
 {% set hashkey = datavault4dbt.escape_column_names(hashkey) %}
+{%- if has_hashdiff -%}
 {% set hashdiff = datavault4dbt.escape_column_names(hashdiff) %}
+{%- endif -%}
 
 WITH
 
@@ -30,7 +35,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
@@ -42,7 +49,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/oracle/ref_sat_v0.sql
+++ b/macros/tables/oracle/ref_sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 
@@ -91,7 +88,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -131,7 +128,6 @@ deduplicated_numbered_source AS (
         AND rn = 1
         {%- endif %}
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#

--- a/macros/tables/oracle/ref_sat_v0.sql
+++ b/macros/tables/oracle/ref_sat_v0.sql
@@ -67,6 +67,8 @@ latest_entries_in_sat_prep AS (
         {% endfor %}
         {%- if has_hashdiff %}
         {{ ns.hdiff_alias }},
+        {%- elif dedup_column is not none %}
+        {{ dedup_column }},
         {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) as rn
     FROM

--- a/macros/tables/oracle/ref_sat_v0.sql
+++ b/macros/tables/oracle/ref_sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/oracle/ref_sat_v0.sql
+++ b/macros/tables/oracle/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +42,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -56,27 +65,31 @@ latest_entries_in_sat_prep AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.hdiff_alias }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM 
+    FROM
         {{ this }}
 ),
 
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source_prep AS (
@@ -85,12 +98,14 @@ deduplicated_numbered_source_prep AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 ),
 
@@ -100,15 +115,19 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
         {% if is_incremental() -%}
         AND rn = 1
         {%- endif %}
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -120,18 +139,22 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
             )
     {%- endif %}
 

--- a/macros/tables/oracle/ref_sat_v0.sql
+++ b/macros/tables/oracle/ref_sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/oracle/ref_sat_v1.sql
+++ b/macros/tables/oracle/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,7 +28,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -38,7 +43,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/oracle/ref_sat_v1.sql
+++ b/macros/tables/oracle/ref_sat_v1.sql
@@ -33,8 +33,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -48,14 +50,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN 1
         ELSE 0
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/oracle/sat_v0.sql
+++ b/macros/tables/oracle/sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 

--- a/macros/tables/oracle/sat_v0.sql
+++ b/macros/tables/oracle/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -21,6 +30,8 @@
 {%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_payload, additional_columns]) -%}
 
 {%- set source_relation = ref(source_model) -%}
+
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -31,7 +42,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -50,12 +63,14 @@ latest_entries_in_sat_prep AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ ns.hdiff_alias }},
+        {%- if dedup_column is not none %}
+        {{ dedup_column }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM 
+    FROM
         {{ this }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
 ),
@@ -63,28 +78,34 @@ latest_entries_in_sat_prep AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
+{%- if payload_count > 0 %}
 deduplicated_numbered_source_prep AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 
 ),
@@ -93,15 +114,18 @@ deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
         {% if is_incremental() -%}
         AND rn = 1
         {%- endif %}
 ),
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -111,15 +135,19 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
-        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }})
+        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/oracle/sat_v0.sql
+++ b/macros/tables/oracle/sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/oracle/sat_v0.sql
+++ b/macros/tables/oracle/sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/oracle/sat_v1.sql
+++ b/macros/tables/oracle/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/postgres/ref_sat_v0.sql
+++ b/macros/tables/postgres/ref_sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 
@@ -91,7 +88,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -131,7 +128,6 @@ deduplicated_numbered_source AS (
         AND rn = 1
         {%- endif %}
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#

--- a/macros/tables/postgres/ref_sat_v0.sql
+++ b/macros/tables/postgres/ref_sat_v0.sql
@@ -67,6 +67,8 @@ latest_entries_in_sat_prep AS (
         {% endfor %}
         {%- if has_hashdiff %}
         {{ ns.hdiff_alias }},
+        {%- elif dedup_column is not none %}
+        {{ dedup_column }},
         {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) as rn
     FROM

--- a/macros/tables/postgres/ref_sat_v0.sql
+++ b/macros/tables/postgres/ref_sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/postgres/ref_sat_v0.sql
+++ b/macros/tables/postgres/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +42,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -56,27 +65,31 @@ latest_entries_in_sat_prep AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.hdiff_alias }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM 
+    FROM
         {{ this }}
 ),
 
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source_prep AS (
@@ -85,12 +98,14 @@ deduplicated_numbered_source_prep AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key|lower}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 ),
 
@@ -100,15 +115,19 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
         {% if is_incremental() -%}
         AND rn = 1
         {%- endif %}
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -120,18 +139,22 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
             )
     {%- endif %}
 

--- a/macros/tables/postgres/ref_sat_v0.sql
+++ b/macros/tables/postgres/ref_sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/postgres/ref_sat_v1.sql
+++ b/macros/tables/postgres/ref_sat_v1.sql
@@ -33,8 +33,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -48,14 +50,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/postgres/ref_sat_v1.sql
+++ b/macros/tables/postgres/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,7 +28,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -38,7 +43,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/postgres/sat_v0.sql
+++ b/macros/tables/postgres/sat_v0.sql
@@ -54,7 +54,6 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/postgres/sat_v0.sql
+++ b/macros/tables/postgres/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -21,6 +30,8 @@
 {%- set source_cols = datavault4dbt.expand_column_list(columns=[src_rsrc, src_ldts, src_payload, additional_columns]) -%}
 
 {%- set source_relation = ref(source_model) -%}
+
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 
 {{ datavault4dbt.prepend_generated_by() }}
 
@@ -31,7 +42,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -50,12 +63,14 @@ latest_entries_in_sat_prep AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ ns.hdiff_alias }},
+        {%- if dedup_column is not none %}
+        {{ dedup_column }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM 
+    FROM
         {{ this }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
 ),
@@ -63,28 +78,34 @@ latest_entries_in_sat_prep AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
+{%- if payload_count > 0 %}
 deduplicated_numbered_source_prep AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 
 ),
@@ -93,15 +114,18 @@ deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
         {% if is_incremental() -%}
         AND rn = 1
         {%- endif %}
 ),
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -111,15 +135,19 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
-        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }})
+        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/postgres/sat_v0.sql
+++ b/macros/tables/postgres/sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/postgres/sat_v1.sql
+++ b/macros/tables/postgres/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - interval '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/redshift/ref_sat_v0.sql
+++ b/macros/tables/redshift/ref_sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 
@@ -75,7 +72,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -101,7 +98,6 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#
@@ -130,7 +126,7 @@ records_to_insert AS (
             {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {%- endif %}
-            {%- if has_hashdiff and payload_count > 0 %}
+            {%- if payload_count > 0 %}
             AND {{ last_cte }}.rn = 1
             {%- endif %})
     {%- endif %}

--- a/macros/tables/redshift/ref_sat_v0.sql
+++ b/macros/tables/redshift/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +42,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -53,18 +62,20 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }} redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
@@ -73,7 +84,9 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
@@ -81,10 +94,12 @@ deduplicated_numbered_source AS (
     FROM source_data redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -96,19 +111,25 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
+            {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/redshift/ref_sat_v0.sql
+++ b/macros/tables/redshift/ref_sat_v0.sql
@@ -127,7 +127,7 @@ records_to_insert AS (
             {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {%- endif %}
-            {%- if payload_count > 0 %}
+            {%- if has_hashdiff and payload_count > 0 %}
             AND {{ last_cte }}.rn = 1
             {%- endif %})
     {%- endif %}

--- a/macros/tables/redshift/ref_sat_v0.sql
+++ b/macros/tables/redshift/ref_sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/redshift/ref_sat_v0.sql
+++ b/macros/tables/redshift/ref_sat_v0.sql
@@ -54,6 +54,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/redshift/ref_sat_v1.sql
+++ b/macros/tables/redshift/ref_sat_v1.sql
@@ -33,8 +33,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -48,14 +50,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/redshift/ref_sat_v1.sql
+++ b/macros/tables/redshift/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,7 +28,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -38,7 +43,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/redshift/sat_v0.sql
+++ b/macros/tables/redshift/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="", last_cte="") -%}
 
-{%- if src_hashdiff is mapping and src_hashdiff is not none -%}
-    {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
-    {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
-{% else -%}
-    {%- set ns.src_hashdiff = src_hashdiff -%}
-    {%- set ns.hdiff_alias = src_hashdiff  -%}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -31,7 +40,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -50,12 +61,14 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        sat.{{ parent_hashkey }},
-        sat.{{ ns.hdiff_alias }}
-    FROM 
+        sat.{{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        sat.{{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }} sat
     WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat(parent_hashkey = parent_hashkey) }}
 
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1
@@ -63,16 +76,19 @@ latest_entries_in_sat AS (
 {%- endif %}
 
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
-{% if not source_is_single_batch %}
+{% if not source_is_single_batch and payload_count > 0 %}
 
 deduplicated_numbered_source AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ ns.hdiff_alias }},
+        {%- if has_hashdiff %}
+        {{ dedup_column }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
         {% if is_incremental() -%}
         , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
@@ -80,7 +96,7 @@ deduplicated_numbered_source AS (
     FROM source_data redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
@@ -96,7 +112,9 @@ records_to_insert AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ ns.hdiff_alias }},
+        {%- if has_hashdiff %}
+        {{ dedup_column }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ ns.last_cte }}
     {%- if is_incremental() %}
@@ -104,8 +122,10 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', ns.last_cte], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', ns.last_cte], condition='=') }}
-            {{ 'AND deduplicated_numbered_source.rn = 1' if not source_is_single_batch }})
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', ns.last_cte], condition='=') }}
+        {%- endif %}
+        {{ 'AND deduplicated_numbered_source.rn = 1' if not source_is_single_batch and payload_count > 0 }})
     {%- endif %}
 
     )

--- a/macros/tables/redshift/sat_v0.sql
+++ b/macros/tables/redshift/sat_v0.sql
@@ -125,7 +125,9 @@ records_to_insert AS (
         {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', ns.last_cte], condition='=') }}
         {%- endif %}
-        {{ 'AND deduplicated_numbered_source.rn = 1' if not source_is_single_batch and payload_count > 0 }})
+        {%- if not source_is_single_batch and has_hashdiff and payload_count > 0 %}
+        AND deduplicated_numbered_source.rn = 1
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/redshift/sat_v0.sql
+++ b/macros/tables/redshift/sat_v0.sql
@@ -46,13 +46,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            MAX({{ src_ldts }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                MAX({{ src_ldts }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 ),
 {%- set ns.last_cte = 'source_data' %}

--- a/macros/tables/redshift/sat_v0.sql
+++ b/macros/tables/redshift/sat_v0.sql
@@ -52,6 +52,7 @@ source_data AS (
             MAX({{ src_ldts }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 {%- set ns.last_cte = 'source_data' %}

--- a/macros/tables/redshift/sat_v0.sql
+++ b/macros/tables/redshift/sat_v0.sql
@@ -46,15 +46,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                MAX({{ src_ldts }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            MAX({{ src_ldts }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 ),
 {%- set ns.last_cte = 'source_data' %}
@@ -128,7 +125,7 @@ records_to_insert AS (
         {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', ns.last_cte], condition='=') }}
         {%- endif %}
-        {%- if not source_is_single_batch and has_hashdiff and payload_count > 0 %}
+        {%- if not source_is_single_batch and payload_count > 0 %}
         AND deduplicated_numbered_source.rn = 1
         {%- endif %})
     {%- endif %}

--- a/macros/tables/redshift/sat_v1.sql
+++ b/macros/tables/redshift/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - interval '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/ref_sat_v0.sql
+++ b/macros/tables/ref_sat_v0.sql
@@ -49,14 +49,23 @@
 
 
     {%- set parent_ref_keys         = datavault4dbt.yaml_metadata_parser(name='parent_ref_keys', yaml_metadata=yaml_metadata, parameter=parent_ref_keys, required=True, documentation=parent_ref_keys_description) -%}
-    {%- set src_hashdiff            = datavault4dbt.yaml_metadata_parser(name='src_hashdiff', yaml_metadata=yaml_metadata, parameter=src_hashdiff, required=True, documentation=src_hashdiff_description) -%}
-    {%- set src_payload             = datavault4dbt.yaml_metadata_parser(name='src_payload', yaml_metadata=yaml_metadata, parameter=src_payload, required=True, documentation=src_payload_description) -%}
+    {%- set src_hashdiff            = datavault4dbt.yaml_metadata_parser(name='src_hashdiff', yaml_metadata=yaml_metadata, parameter=src_hashdiff, required=False, documentation=src_hashdiff_description) -%}
+    {%- set src_payload             = datavault4dbt.yaml_metadata_parser(name='src_payload', yaml_metadata=yaml_metadata, parameter=src_payload, required=False, documentation=src_payload_description) -%}
     {%- set source_model            = datavault4dbt.yaml_metadata_parser(name='source_model', yaml_metadata=yaml_metadata, parameter=source_model, required=True, documentation=source_model_description) -%}
     {%- set src_ldts                = datavault4dbt.yaml_metadata_parser(name='src_ldts', yaml_metadata=yaml_metadata, parameter=src_ldts, required=False, documentation=src_ldts_description) -%}
     {%- set src_rsrc                = datavault4dbt.yaml_metadata_parser(name='src_rsrc', yaml_metadata=yaml_metadata, parameter=src_rsrc, required=False, documentation=src_rsrc_description) -%}
     {%- set disable_hwm             = datavault4dbt.yaml_metadata_parser(name='disable_hwm', yaml_metadata=yaml_metadata, parameter=disable_hwm, required=False, documentation='Whether the High Water Mark should be turned off. Optional, default False.') -%}
     {%- set source_is_single_batch  = datavault4dbt.yaml_metadata_parser(name='source_is_single_batch', yaml_metadata=yaml_metadata, parameter=source_is_single_batch, required=False, documentation='Whether the source contains only one batch. Optional, default False.') -%}
     {%- set additional_columns      = datavault4dbt.yaml_metadata_parser(name='additional_columns', yaml_metadata=yaml_metadata, parameter=additional_columns, required=False, documentation=additional_columns_description) -%}
+
+    {%- set src_payload = src_payload | default([], true) -%}
+    {%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+    {%- set payload_count = src_payload | length -%}
+    {%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
+    {%- if payload_count >= 2 and not has_hashdiff -%}
+        {{ exceptions.raise_compiler_error("datavault4dbt.ref_sat_v0: src_hashdiff is required when src_payload has more than one column. Provide a hashdiff column or reduce src_payload to a single column.") }}
+    {%- endif -%}
 
     {# Applying the default aliases as stored inside the global variables, if src_ldts, src_rsrc, and ledts_alias are not set. #}
     {%- set src_ldts = datavault4dbt.replace_standard(src_ldts, 'datavault4dbt.ldts_alias', 'ldts') -%}

--- a/macros/tables/ref_sat_v1.sql
+++ b/macros/tables/ref_sat_v1.sql
@@ -36,7 +36,7 @@
 
     {%- set ref_sat_v0          = datavault4dbt.yaml_metadata_parser(name='ref_sat_v0', yaml_metadata=yaml_metadata, parameter=ref_sat_v0, required=True, documentation=ref_sat_v0_description) -%}
     {%- set ref_keys            = datavault4dbt.yaml_metadata_parser(name='ref_keys', yaml_metadata=yaml_metadata, parameter=ref_keys, required=True, documentation=ref_keys_description) -%}
-    {%- set hashdiff            = datavault4dbt.yaml_metadata_parser(name='hashdiff', yaml_metadata=yaml_metadata, parameter=hashdiff, required=True, documentation=hashdiff_description) -%}
+    {%- set hashdiff            = datavault4dbt.yaml_metadata_parser(name='hashdiff', yaml_metadata=yaml_metadata, parameter=hashdiff, required=False, documentation=hashdiff_description) -%}
     {%- set src_ldts            = datavault4dbt.yaml_metadata_parser(name='src_ldts', yaml_metadata=yaml_metadata, parameter=src_ldts, required=False, documentation=src_ldts_description) -%}
     {%- set src_rsrc            = datavault4dbt.yaml_metadata_parser(name='src_rsrc', yaml_metadata=yaml_metadata, parameter=src_rsrc, required=False, documentation=src_rsrc_description) -%}
     {%- set ledts_alias         = datavault4dbt.yaml_metadata_parser(name='ledts_alias', yaml_metadata=yaml_metadata, parameter=ledts_alias, required=False, documentation=ledts_alias_description) -%}

--- a/macros/tables/sat_v0.sql
+++ b/macros/tables/sat_v0.sql
@@ -67,14 +67,23 @@
     " %}
 
     {%- set parent_hashkey          = datavault4dbt.yaml_metadata_parser(name='parent_hashkey', yaml_metadata=yaml_metadata, parameter=parent_hashkey, required=True, documentation=parent_hashkey_description) -%}
-    {%- set src_hashdiff            = datavault4dbt.yaml_metadata_parser(name='src_hashdiff', yaml_metadata=yaml_metadata, parameter=src_hashdiff, required=True, documentation=src_hashdiff_description) -%}
-    {%- set src_payload             = datavault4dbt.yaml_metadata_parser(name='src_payload', yaml_metadata=yaml_metadata, parameter=src_payload, required=True, documentation=src_payload_description) -%}
+    {%- set src_hashdiff            = datavault4dbt.yaml_metadata_parser(name='src_hashdiff', yaml_metadata=yaml_metadata, parameter=src_hashdiff, required=False, documentation=src_hashdiff_description) -%}
+    {%- set src_payload             = datavault4dbt.yaml_metadata_parser(name='src_payload', yaml_metadata=yaml_metadata, parameter=src_payload, required=False, documentation=src_payload_description) -%}
     {%- set source_model            = datavault4dbt.yaml_metadata_parser(name='source_model', yaml_metadata=yaml_metadata, parameter=source_model, required=True, documentation=source_model_description) -%}
     {%- set src_ldts                = datavault4dbt.yaml_metadata_parser(name='src_ldts', yaml_metadata=yaml_metadata, parameter=src_ldts, required=False, documentation=src_ldts_description) -%}
     {%- set src_rsrc                = datavault4dbt.yaml_metadata_parser(name='src_rsrc', yaml_metadata=yaml_metadata, parameter=src_rsrc, required=False, documentation=src_rsrc_description) -%}
     {%- set disable_hwm             = datavault4dbt.yaml_metadata_parser(name='disable_hwm', yaml_metadata=yaml_metadata, parameter=disable_hwm, required=False, documentation='Whether the High Water Mark should be turned off. Optional, default False.') -%}
     {%- set source_is_single_batch  = datavault4dbt.yaml_metadata_parser(name='source_is_single_batch', yaml_metadata=yaml_metadata, parameter=source_is_single_batch, required=False, documentation='Whether the source contains only one batch. Optional, default False.') -%}
     {%- set additional_columns      = datavault4dbt.yaml_metadata_parser(name='additional_columns', yaml_metadata=yaml_metadata, parameter=additional_columns, required=False, documentation=additional_columns_description) -%}
+
+    {%- set src_payload = src_payload | default([], true) -%}
+    {%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+    {%- set payload_count = src_payload | length -%}
+    {%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
+    {%- if payload_count >= 2 and not has_hashdiff -%}
+        {{ exceptions.raise_compiler_error("datavault4dbt.sat_v0: src_hashdiff is required when src_payload has more than one column. Provide a hashdiff column or reduce src_payload to a single column.") }}
+    {%- endif -%}
 
     {# Applying the default aliases as stored inside the global variables, if src_ldts, src_rsrc, and ledts_alias are not set. #}
     {%- set src_ldts = datavault4dbt.replace_standard(src_ldts, 'datavault4dbt.ldts_alias', 'ldts') -%}

--- a/macros/tables/sat_v1.sql
+++ b/macros/tables/sat_v1.sql
@@ -64,7 +64,7 @@
 
     {%- set sat_v0              = datavault4dbt.yaml_metadata_parser(name='sat_v0', yaml_metadata=yaml_metadata, parameter=sat_v0, required=True, documentation=sat_v0_description) -%}
     {%- set hashkey             = datavault4dbt.yaml_metadata_parser(name='hashkey', yaml_metadata=yaml_metadata, parameter=hashkey, required=True, documentation=hashkey_description) -%}
-    {%- set hashdiff            = datavault4dbt.yaml_metadata_parser(name='hashdiff', yaml_metadata=yaml_metadata, parameter=hashdiff, required=True, documentation=hashdiff_description) -%}
+    {%- set hashdiff            = datavault4dbt.yaml_metadata_parser(name='hashdiff', yaml_metadata=yaml_metadata, parameter=hashdiff, required=False, documentation=hashdiff_description) -%}
     {%- set src_ldts            = datavault4dbt.yaml_metadata_parser(name='src_ldts', yaml_metadata=yaml_metadata, parameter=src_ldts, required=False, documentation=src_ldts_description) -%}
     {%- set src_rsrc            = datavault4dbt.yaml_metadata_parser(name='src_rsrc', yaml_metadata=yaml_metadata, parameter=src_rsrc, required=False, documentation=src_rsrc_description) -%}
     {%- set ledts_alias         = datavault4dbt.yaml_metadata_parser(name='ledts_alias', yaml_metadata=yaml_metadata, parameter=ledts_alias, required=False, documentation=ledts_alias_description) -%}

--- a/macros/tables/snowflake/ref_sat_v0.sql
+++ b/macros/tables/snowflake/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -42,7 +49,9 @@ source_data AS (
 
     SELECT
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
     FROM {{ source_relation }}
 
@@ -56,23 +65,29 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         {{ this }}
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }} ORDER BY {{ src_ldts }} DESC) = 1  
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }} ORDER BY {{ src_ldts }} DESC) = 1
 ),
 {%- endif %}
 
+{%- set last_cte = 'source_data' -%}
+{%- if payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
 
     SELECT
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }},
-        {{ ns.hdiff_alias }},
+        {%- if has_hashdiff %}
+        {{ dedup_column }},
+        {%- endif %}
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }} ORDER BY {{ src_ldts }}) as rn
@@ -80,10 +95,12 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- set last_cte = 'deduplicated_numbered_source' -%}
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -93,19 +110,25 @@ records_to_insert AS (
 
     SELECT
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(parent_ref_keys)) }},
-        {{ ns.hdiff_alias }},
+        {%- if has_hashdiff %}
+        {{ dedup_column }},
+        {%- endif %}
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE 1=1
             {% for ref_key in parent_ref_keys %}
-            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
+            AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+            {%- endif %}
+            {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/snowflake/ref_sat_v0.sql
+++ b/macros/tables/snowflake/ref_sat_v0.sql
@@ -57,6 +57,7 @@ source_data AS (
 
     {%- if is_incremental() and not disable_hwm %}
     WHERE {{ src_ldts }} > '{{ max_ldts }}'
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/snowflake/ref_sat_v0.sql
+++ b/macros/tables/snowflake/ref_sat_v0.sql
@@ -55,11 +55,8 @@ source_data AS (
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > '{{ max_ldts }}'
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > '{{ max_ldts }}'
     {%- endif %}
 ),
 
@@ -78,7 +75,7 @@ latest_entries_in_sat AS (
 ),
 {%- endif %}
 
-{%- set last_cte = 'source_data' -%}
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
 {%- if payload_count > 0 %}
 {#
     Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
@@ -102,7 +99,6 @@ deduplicated_numbered_source AS (
             ELSE TRUE
         END
 ),
-{%- set last_cte = 'deduplicated_numbered_source' -%}
 {%- endif %}
 
 {#

--- a/macros/tables/snowflake/ref_sat_v0.sql
+++ b/macros/tables/snowflake/ref_sat_v0.sql
@@ -55,9 +55,11 @@ source_data AS (
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > '{{ max_ldts }}'
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > '{{ max_ldts }}'
+        {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/snowflake/ref_sat_v1.sql
+++ b/macros/tables/snowflake/ref_sat_v1.sql
@@ -31,8 +31,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
-        {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) if source_columns_to_select else " *" }}
+        COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
+        {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -44,14 +46,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
-    {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) if source_columns_to_select else " *" }}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
+    {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/snowflake/ref_sat_v1.sql
+++ b/macros/tables/snowflake/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -23,7 +26,9 @@ end_dated_source AS (
 
     SELECT
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -57,7 +57,6 @@ source_data AS (
 
     {%- if is_incremental() %}
     WHERE {{ src_ldts }} > '{{ max_ldts }}'
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -57,6 +57,7 @@ source_data AS (
 
     {%- if is_incremental() %}
     WHERE {{ src_ldts }} > '{{ max_ldts }}'
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 ),
 

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -40,7 +49,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
     FROM {{ source_relation }}
 
@@ -54,28 +65,36 @@ source_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
     FROM
         {{ this }}
     WHERE 1=1
-    
+
     {{ datavault4dbt.filter_latest_entries_in_sat(parent_hashkey = parent_hashkey) }}
-    
+
     QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }} DESC) = 1
 
 ),
 {%- endif %}
 
+{%- set last_cte = 'deduplicated_numbered_source' if payload_count > 0 else 'source_data' -%}
+
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
+{%- if payload_count > 0 %}
 deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
@@ -83,10 +102,11 @@ deduplicated_numbered_source AS (
     FROM source_data
     QUALIFY
         CASE
-            WHEN {{ ns.hdiff_alias }} = LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
+            WHEN {{ dedup_column }} = LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) THEN FALSE
             ELSE TRUE
         END
 ),
+{%- endif %}
 
 {#
     Select all records from the previous CTE. If incremental, compare the oldest incoming entry to
@@ -96,16 +116,22 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_cols)) if source_cols else " *" }}
-    FROM deduplicated_numbered_source
+    FROM {{ last_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
         FROM latest_entries_in_sat
-        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'deduplicated_numbered_source'], condition='=') }}
-            AND deduplicated_numbered_source.rn = 1)
+        WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %}
+        {%- if payload_count > 0 %}
+            AND {{ last_cte }}.rn = 1
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/snowflake/sat_v1.sql
+++ b/macros/tables/snowflake/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/synapse/ref_sat_v0.sql
+++ b/macros/tables/synapse/ref_sat_v0.sql
@@ -6,15 +6,22 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +42,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {%- endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -47,7 +56,7 @@ source_data AS (
     )
     AND {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
-    
+
     {%- set source_cte = 'source_data' -%}
 
     -- UNION ALL ghost record 000000
@@ -58,12 +67,12 @@ source_data AS (
 target_data AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
         , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) AS rn
-    FROM 
+    FROM
         {{ this }}
 ),
 {%- endif %}
@@ -73,20 +82,20 @@ target_data AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         target_data
     WHERE rn = 1
 ),
 {%- endif %}
 
-{%- if not source_is_single_batch %}
+{%- if not source_is_single_batch and payload_count > 0 %}
 
 {#
-    Adding hashdiff of the previous record, for each parent ref key combination.
+    Adding dedup column of the previous record, for each parent ref key combination.
 #}
 numbered_source AS (
 
@@ -94,14 +103,16 @@ numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) prev_dedup_col
     FROM source_data
 ),
 
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
 #}
 deduplicated_numbered_source AS (
@@ -110,13 +121,15 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
     FROM numbered_source
-    WHERE {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+    WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 
@@ -134,7 +147,9 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_cte }} sc
     {%- if is_incremental() %}
@@ -145,8 +160,10 @@ records_to_insert AS (
             {% for ref_key in parent_ref_keys %}
             AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
-            {%- if not source_is_single_batch %}
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
+            {%- endif %}
+            {%- if not source_is_single_batch and payload_count > 0 %}
             AND sc.rn = 1
             {%- endif %}
             )

--- a/macros/tables/synapse/ref_sat_v0.sql
+++ b/macros/tables/synapse/ref_sat_v0.sql
@@ -48,13 +48,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental()  and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/synapse/ref_sat_v0.sql
+++ b/macros/tables/synapse/ref_sat_v0.sql
@@ -48,15 +48,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} <> {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            COALESCE (MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/synapse/ref_sat_v1.sql
+++ b/macros/tables/synapse/ref_sat_v1.sql
@@ -33,8 +33,10 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }},
+        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -48,14 +50,16 @@ SELECT
     {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN 1
         ELSE 0
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/synapse/ref_sat_v1.sql
+++ b/macros/tables/synapse/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,7 +28,9 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }},
@@ -38,7 +43,9 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }},

--- a/macros/tables/synapse/sat_v0.sql
+++ b/macros/tables/synapse/sat_v0.sql
@@ -52,6 +52,7 @@ source_data AS (
             COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
         WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     )
+    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/synapse/sat_v0.sql
+++ b/macros/tables/synapse/sat_v0.sql
@@ -46,15 +46,12 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() %}
-    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        {%- if not disable_hwm %}
-        AND {{ src_ldts }} > (
-            SELECT
-                COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-        )
-        {%- endif %}
+    {%- if is_incremental() and not disable_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT
+            COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/synapse/sat_v0.sql
+++ b/macros/tables/synapse/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -31,7 +40,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -61,13 +72,15 @@ latest_entries_in_sat_prep AS (
 
     SELECT
         tgt.{{ parent_hashkey }},
-        tgt.{{ ns.hdiff_alias }},
+        {%- if dedup_column is not none %}
+        tgt.{{ dedup_column }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY tgt.{{ parent_hashkey|lower }} ORDER BY tgt.{{ src_ldts }} DESC) as rn
     FROM {{ this }} tgt
     INNER JOIN distinct_incoming_hashkeys src
         ON tgt.{{ parent_hashkey }} = src.{{ parent_hashkey }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
 ),
@@ -75,26 +88,31 @@ latest_entries_in_sat_prep AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
-{%- if not source_is_single_batch %}
+{%- if not source_is_single_batch and payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
 deduplicated_numbered_source_prep AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    , LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    , LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey|lower }} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 
 ),
@@ -103,14 +121,16 @@ deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
     , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 
@@ -126,7 +146,9 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_cte }} sc
     {%- if is_incremental() %}
@@ -134,8 +156,10 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
-            {%- if not source_is_single_batch %}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
+        {%- endif %}
+            {%- if not source_is_single_batch and payload_count > 0 %}
             AND sc.rn = 1
             {%- endif %}
     )

--- a/macros/tables/synapse/sat_v0.sql
+++ b/macros/tables/synapse/sat_v0.sql
@@ -46,13 +46,15 @@ source_data AS (
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
-    {%- if is_incremental() and not disable_hwm %}
-    WHERE {{ src_ldts }} > (
-        SELECT
-            COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
-        WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
-    )
-    AND {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    {%- if is_incremental() %}
+    WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        {%- if not disable_hwm %}
+        AND {{ src_ldts }} > (
+            SELECT
+                COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}) FROM {{ this }}
+            WHERE {{ src_ldts }} != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+        )
+        {%- endif %}
     {%- endif %}
 
     {%- set source_cte = 'source_data' -%}

--- a/macros/tables/synapse/sat_v1.sql
+++ b/macros/tables/synapse/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
@@ -33,7 +38,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}

--- a/macros/tables/trino/ref_sat_v0.sql
+++ b/macros/tables/trino/ref_sat_v0.sql
@@ -6,15 +6,24 @@
 
 {%- set parent_ref_keys = datavault4dbt.expand_column_list(columns=[parent_ref_keys]) -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -35,7 +44,9 @@ source_data AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -57,29 +68,32 @@ latest_entries_in_sat_prep AS (
         {% for ref_key in parent_ref_keys %}
         {{ref_key}},
         {% endfor %}
-        {{ ns.hdiff_alias }},
+        {%- if dedup_column is not none %}
+        {{ dedup_column }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM 
+    FROM
         {{ this }}
 ),
 
 latest_entries_in_sat AS (
 
     SELECT
-        {% for ref_key in parent_ref_keys %}
-        {{ref_key}},
-        {% endfor %}
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ datavault4dbt.print_list(parent_ref_keys) }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
     WHERE rn = 1
 ),
 {%- endif %}
 
-{%- if not source_is_single_batch %}
+{%- if not source_is_single_batch and payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each parent ref key combination.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each parent ref key combination.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
 deduplicated_numbered_source_prep AS (
 
@@ -87,9 +101,11 @@ deduplicated_numbered_source_prep AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }},
-    LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    LAG({{ dedup_column }}) OVER(PARTITION BY {%- for ref_key in parent_ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 ),
 
@@ -99,10 +115,12 @@ deduplicated_numbered_source AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM deduplicated_numbered_source_prep
-    WHERE {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+    WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 ),
@@ -117,9 +135,11 @@ records_to_insert AS (
     {% for ref_key in parent_ref_keys %}
     {{ref_key}},
     {% endfor %}
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
-    FROM {{ source_cte }} 
+    FROM {{ source_cte }}
     {%- if is_incremental() %}
     WHERE NOT EXISTS (
         SELECT 1
@@ -128,7 +148,9 @@ records_to_insert AS (
             {% for ref_key in parent_ref_keys %}
             AND {{ datavault4dbt.multikey(ref_key, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
             {% endfor %}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
+            {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
+            {%- endif %}
             )
     {%- endif %}
 

--- a/macros/tables/trino/ref_sat_v1.sql
+++ b/macros/tables/trino/ref_sat_v1.sql
@@ -7,10 +7,13 @@
 
 {%- set source_relation = ref(ref_sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set ref_keys = datavault4dbt.expand_column_list(columns=[ref_keys]) -%}
 
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = ref_keys + [hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = ref_keys + [src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -25,11 +28,15 @@ end_dated_source AS (
         {% for ref_key in ref_keys %}
         {{ref_key}},
         {% endfor %}
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }},
+        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
+        {%- endif %}
     FROM {{ source_relation }}
 
 )
@@ -38,17 +45,21 @@ SELECT
     {% for ref_key in ref_keys %}
     {{ref_key}},
     {% endfor %}
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
-    {{ ledts_alias }},
-    {%- if add_is_current_flag %}
+    {{ ledts_alias }}
+    {%- if add_is_current_flag %},
         CASE WHEN {{ ledts_alias }} = {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
         THEN TRUE
         ELSE FALSE
-        END AS {{ is_current_col_alias }},
-    {% endif -%}
+        END AS {{ is_current_col_alias }}
+    {%- endif %}
+    {%- if source_columns_to_select -%},
     {{ datavault4dbt.print_list(source_columns_to_select) }}
+    {%- endif %}
 FROM end_dated_source
 
 {%- endmacro -%}

--- a/macros/tables/trino/sat_v0.sql
+++ b/macros/tables/trino/sat_v0.sql
@@ -4,15 +4,24 @@
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 
+{%- set src_payload = src_payload | default([], true) -%}
+{%- set src_payload = [src_payload] if src_payload is string else src_payload -%}
+{%- set payload_count = src_payload | length -%}
+{%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
+
 {%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
 
-{%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
-    {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
-    {% set ns.hdiff_alias = src_hashdiff["alias"] %}
-{% else %}
-    {% set ns.src_hashdiff = src_hashdiff %}
-    {% set ns.hdiff_alias = src_hashdiff  %}
+{%- if has_hashdiff -%}
+    {%- if src_hashdiff is mapping -%}
+        {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
+        {%- set ns.hdiff_alias = src_hashdiff["alias"] -%}
+    {%- else -%}
+        {%- set ns.src_hashdiff = src_hashdiff -%}
+        {%- set ns.hdiff_alias = src_hashdiff -%}
+    {%- endif -%}
 {%- endif -%}
+
+{%- set dedup_column = ns.hdiff_alias if has_hashdiff else (src_payload[0] if payload_count == 1 else none) -%}
 
 {# Select the additional_columns and put them in an array. If additional_colums none, then empty array #}
 {%- set additional_columns = additional_columns | default([],true) -%}
@@ -31,7 +40,9 @@ source_data AS (
 
     SELECT
         {{ parent_hashkey }},
+        {%- if has_hashdiff %}
         {{ ns.src_hashdiff }} as {{ ns.hdiff_alias }},
+        {%- endif %}
         {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_relation }}
 
@@ -53,12 +64,14 @@ latest_entries_in_sat_prep AS (
 
     SELECT
         {{ parent_hashkey }},
-        {{ ns.hdiff_alias }},
+        {%- if dedup_column is not none %}
+        {{ dedup_column }},
+        {%- endif %}
         ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
-    FROM 
+    FROM
         {{ this }}
      WHERE 1=1
-        
+
     {{ datavault4dbt.filter_latest_entries_in_sat() }}
 
 ),
@@ -66,26 +79,31 @@ latest_entries_in_sat_prep AS (
 latest_entries_in_sat AS (
 
     SELECT
-        {{ parent_hashkey }},
-        {{ ns.hdiff_alias }}
-    FROM 
+        {{ parent_hashkey }}
+        {%- if dedup_column is not none -%},
+        {{ dedup_column }}
+        {%- endif %}
+    FROM
         latest_entries_in_sat_prep
-    WHERE rn = 1  
+    WHERE rn = 1
 ),
 {%- endif %}
 
-{%- if not source_is_single_batch %}
+{%- if not source_is_single_batch and payload_count > 0 %}
 {#
-    Deduplicate source by comparing each hashdiff to the hashdiff of the previous record, for each hashkey.
+    Deduplicate source by comparing each hashdiff/payload value to the value of the previous record, for each hashkey.
     Additionally adding a row number based on that order, if incremental.
+    Skipped entirely when no payload is provided (Modus C).
 #}
 deduplicated_numbered_source_prep AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }},
-    LAG({{ ns.hdiff_alias }}) OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as prev_hashdiff
+    LAG({{ dedup_column }}) OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as prev_dedup_col
     FROM source_data
 
 ),
@@ -94,10 +112,12 @@ deduplicated_numbered_source AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM deduplicated_numbered_source_prep
-    WHERE {{ ns.hdiff_alias }} <> prev_hashdiff OR prev_hashdiff IS NULL
+    WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 
@@ -113,7 +133,9 @@ records_to_insert AS (
 
     SELECT
     {{ parent_hashkey }},
-    {{ ns.hdiff_alias }},
+    {%- if has_hashdiff %}
+    {{ dedup_column }},
+    {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     FROM {{ source_cte }}
     {%- if is_incremental() %}
@@ -121,7 +143,9 @@ records_to_insert AS (
         SELECT 1
         FROM latest_entries_in_sat
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
-            AND {{ datavault4dbt.multikey(ns.hdiff_alias, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
+        {%- if dedup_column is not none %}
+            AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
+        {%- endif %}
     )
     {%- endif %}
 

--- a/macros/tables/trino/sat_v1.sql
+++ b/macros/tables/trino/sat_v1.sql
@@ -7,8 +7,11 @@
 
 {%- set source_relation = ref(sat_v0) -%}
 
+{%- set has_hashdiff = hashdiff is not none and hashdiff != '' -%}
+
 {%- set all_columns = datavault4dbt.source_columns(source_relation=source_relation) -%}
-{%- set exclude = [hashkey, hashdiff, src_ldts, src_rsrc] -%}
+{%- set exclude = [hashkey, src_ldts, src_rsrc] -%}
+{%- if has_hashdiff %}{%- do exclude.append(hashdiff) -%}{%- endif %}
 
 {%- set source_columns_to_select = datavault4dbt.process_columns_to_select(all_columns, exclude) -%}
 
@@ -21,7 +24,9 @@ end_dated_source AS (
 
     SELECT
         {{ hashkey }},
+        {%- if has_hashdiff %}
         {{ hashdiff }},
+        {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
         COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
@@ -34,7 +39,9 @@ end_dated_source AS (
 
 SELECT
     {{ hashkey }},
+    {%- if has_hashdiff %}
     {{ hashdiff }},
+    {%- endif %}
     {{ src_rsrc }},
     {{ src_ldts }},
     {{ ledts_alias }}


### PR DESCRIPTION
# Description

# feat: optional `src_payload` for Satellites and Reference Satellites

Makes `src_payload`  (as well as `src_hashdiff`) optional across all satellite macros (`sat_v0`, `sat_v1`, `ref_sat_v0`, `ref_sat_v1`) for all 9 supported database adapters. This introduces two new ways to use satellites alongside the existing classic approach.

---

## Three ways to use satellites

| Mode | `src_payload` | `src_hashdiff` | Behavior |
|---|---|---|---|
| **A — Classic** (unchanged) | ≥ 1 column | set | Hashdiff-based deduplication and insert |
| **B — Single-Attribute** (new) | exactly 1 column | not set | Deduplication compares the payload column directly; no hashdiff column in the output |
| **C — No-Payload / Tracking** (new) | empty / not set | not set | No deduplication; a record is only inserted when a new hashkey appears |

**Validation:** if `src_payload` has more than one column and `src_hashdiff` is not set, dbt will throw a clear compiler error.

---

## What changed

### Top-level dispatchers
`macros/tables/sat_v0.sql`, `sat_v1.sql`, `ref_sat_v0.sql`, `ref_sat_v1.sql`

- `src_payload` and `src_hashdiff` / `hashdiff` are no longer required parameters
- A validation check was added for the case where multiple payload columns are used without a hashdiff

### Dialect implementations
9 adapters × 4 macro types = 36 files

- The deduplication column is now derived from the hashdiff (Mode A), the single payload column (Mode B), or not used at all (Mode C)
- The deduplication CTE is skipped entirely in Mode C
- The hashdiff column is left out of `SELECT` lists and duplicate checks when it is not provided
- Mode B uses the payload column directly in window function comparisons



---

## Backwards compatibility

All existing models that already provide `src_payload` and `src_hashdiff` continue to work without any changes.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested with branch 280-sat-payload-optional of datavault4dbt and branch 280-sat-payload-optional of datavault4dbt-automatic-tests, to make sure that all special cases were covered. Was tested in the CI/CD.