### PR TITLE
Fixed fabric hash convert logic

### DIFF
--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -407,7 +407,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{ expr }}, r'\\', r'\\\\'), 
 
 {%- set zero_key = datavault4dbt.as_constant(column_str=zero_key) -%}
 
-{%- if not ('VARCHAR' in datatype or 'CHAR' in datatype or 'NVARCHAR' in datatype or 'NCHAR' in datatype) %}
+{%- if 'VARCHAR' in datatype or 'CHAR' in datatype or 'NVARCHAR' in datatype or 'NCHAR' in datatype %}
 
     {%- if case_sensitive -%}
     


### PR DESCRIPTION
# Description

Fixes a logic bug in the fabric__concattenated_standardise macro where an accidental not inverted the datatype conditional, causing string types (VARCHAR, CHAR, NVARCHAR, NCHAR) to be handled by the non-string branch and vice versa.

Fixes #(459)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Verified that the generated SQL for a Fabric model with hashed string columns (NVARCHAR/VARCHAR) and non-string hash output types (BINARY(16)) now correctly applies:
  - HASHBYTES(...) for string types
  - CONVERT({datatype}, HASHBYTES(...), 1) for non-string types
  - [ ] Manual review of generated SQL on a Fabric model with mixed hash column types

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
