### PR TITLE
fix(fabric): alias count(*) in rsrc_static row-count query

### DIFF
--- a/macros/tables/fabric/hub.sql
+++ b/macros/tables/fabric/hub.sql
@@ -51,7 +51,7 @@ WITH
             {% if var('datavault4dbt.show_debug_logs', false) %}{{log('rsrc_statics: '~ rsrc_statics, false) }}{% endif %}
 
             {%- set rsrc_static_query_source -%}
-                SELECT count(*) FROM (
+                SELECT count(*) AS cnt FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static

--- a/macros/tables/fabric/link.sql
+++ b/macros/tables/fabric/link.sql
@@ -54,7 +54,7 @@ WITH
             {% if var('datavault4dbt.show_debug_logs', false) %}{{log('rsrc_statics: '~ rsrc_statics, false) }}{% endif %}
 
             {%- set rsrc_static_query_source -%}
-                SELECT count(*) FROM (
+                SELECT count(*) AS cnt FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ src_rsrc }},
                     '{{ rsrc_static }}' AS rsrc_static

--- a/macros/tables/fabric/nh_link.sql
+++ b/macros/tables/fabric/nh_link.sql
@@ -67,7 +67,7 @@ WITH
             {% if var('datavault4dbt.show_debug_logs', false) %}{{log('rsrc_statics: '~ rsrc_statics, false) }}{% endif %}
 
             {%- set rsrc_static_query_source -%}
-                SELECT count(*) FROM (
+                SELECT count(*) AS cnt FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ (src_rsrc) }},
                     '{{ rsrc_static }}' AS rsrc_static

--- a/macros/tables/fabric/rec_track_sat.sql
+++ b/macros/tables/fabric/rec_track_sat.sql
@@ -58,7 +58,7 @@ WITH
             {%- set rsrc_statics = ns.source_models_rsrc_dict[source_number] -%}
 
             {%- set rsrc_static_query_source_count -%}
-                SELECT count(*) FROM (
+                SELECT count(*) AS cnt FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT 
                     {{ tracked_hashkey }},

--- a/macros/tables/fabric/ref_hub.sql
+++ b/macros/tables/fabric/ref_hub.sql
@@ -57,7 +57,7 @@ WITH
             {% if var('datavault4dbt.show_debug_logs', false) %}{{log('rsrc_statics: '~ rsrc_statics, false) }}{% endif %}
 
             {%- set rsrc_static_query_source -%}
-                SELECT count(*) FROM (
+                SELECT count(*) AS cnt FROM (
                 {%- for rsrc_static in rsrc_statics -%}
                     SELECT t.{{ (src_rsrc) }},
                     '{{ rsrc_static }}' AS rsrc_static


### PR DESCRIPTION
Without an alias, agate emits UnnamedColumnWarning when run_query returns the result of `SELECT count(*) FROM (...)`. Alias as `cnt` so the result column has a name.

# Description

Please include a summary of the changes and the related issue and context.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Tests you ran

**Test Configuration**:
* datavault4dbt-Version:
* dbt-Version: _cloud/core, version number_
* dbt-adapter-Version:

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
