### PR TITLE
329 fabric hash algs

### DIFF
--- a/macros/supporting/hash_default_values.sql
+++ b/macros/supporting/hash_default_values.sql
@@ -119,44 +119,40 @@
     {{ log('hash datatype: ' ~ hash_datatype, false) }}
 
     {%- if hash_function == 'MD5' -%}
+        {%- set hash_alg = 'MD5' -%}
         {%- if 'VARCHAR' in hash_datatype|upper or 'CHAR' in hash_datatype|upper or 'STRING' in hash_datatype|upper or 'TEXT' in hash_datatype|upper %}
-            {%- set hash_alg = 'MD5' -%}
-            {%- set unknown_key = "CONVERT(varchar(34), '00000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(34), 'ffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype|upper %}
-            {%- set hash_alg = 'MD5' -%}
-            {%- set unknown_key = "CONVERT(binary(16), '00000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(binary(16), 'ffffffffffffffffffffffffffffffff')" -%}           
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffff')" -%}           
         {%- endif -%} 
-    {%- elif hash_function == 'SHA1' or hash_function == 'SHA1_HEX' or hash_function == 'SHA' -%} 
+    {%- elif hash_function in ['SHA1', 'SHA'] -%} 
+        {%- set hash_alg = 'SHA1' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
-            {%- set hash_alg = 'SHA1' -%}
-            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
-            {%- set hash_alg = 'SHA1_BINARY' -%}
-            {%- set unknown_key = "CONVERT(binary(20), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(binary(20), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}
-    {%- elif hash_function == 'SHA2' or hash_function == 'SHA2_HEX' or hash_function == 'SHA2_256' -%}
+    {%- elif hash_function in ['SHA2', 'SHA2_256'] -%}
+        {%- set hash_alg = 'SHA2_256' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
-            {%- set hash_alg = 'SHA2' -%}
-            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
-            {%- set hash_alg = 'SHA2_BINARY' -%}
-            {%- set unknown_key = "CONVERT(binary(32), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(binary(32), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}   
     {%- elif hash_function == 'SHA2_512' -%}
+        {%- set hash_alg = 'SHA2_512' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
-            {%- set hash_alg = 'SHA2' -%}
-            {%- set unknown_key = "CONVERT(varchar(70), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(70), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
-            {%- set hash_alg = 'SHA2_BINARY' -%}
-            {%- set unknown_key = "CONVERT(binary(64), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(binary(64), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%} 
     {%- endif -%}
 
@@ -178,44 +174,40 @@
     {{ log('hash datatype: ' ~ hash_datatype, false) }}
 
     {%- if hash_function == 'MD5' -%}
+        {%- set hash_alg = 'MD5' -%}
         {%- if 'VARCHAR' in hash_datatype|upper or 'CHAR' in hash_datatype|upper or 'STRING' in hash_datatype|upper or 'TEXT' in hash_datatype|upper %}
-            {%- set hash_alg = 'MD5' -%}
-            {%- set unknown_key = "CONVERT(varchar(34), '00000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(34), 'ffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype|upper %}
-            {%- set hash_alg = 'MD5' -%}
-            {%- set unknown_key = "CONVERT(varbinary(16), '00000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varbinary(16), 'ffffffffffffffffffffffffffffffff')" -%}           
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffff')" -%}           
         {%- endif -%} 
-    {%- elif hash_function == 'SHA1' or hash_function == 'SHA1_HEX' or hash_function == 'SHA' -%} 
+    {%- elif hash_function in ['SHA1', 'SHA'] -%} 
+        {%- set hash_alg = 'SHA1' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
-            {%- set hash_alg = 'SHA1' -%}
-            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
-            {%- set hash_alg = 'SHA1_BINARY' -%}
-            {%- set unknown_key = "CONVERT(varbinary(20), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varbinary(20), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}
-    {%- elif hash_function == 'SHA2' or hash_function == 'SHA2_HEX' or hash_function == 'SHA2_256' -%}
+    {%- elif hash_function in ['SHA2', 'SHA2_256'] -%}
+        {%- set hash_alg = 'SHA2_256' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
-            {%- set hash_alg = 'SHA2' -%}
-            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
-            {%- set hash_alg = 'SHA2_BINARY' -%}
-            {%- set unknown_key = "CONVERT(varbinary(32), '0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varbinary(32), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '0000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}   
     {%- elif hash_function == 'SHA2_512' -%}
+        {%- set hash_alg = 'SHA2_512' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
-            {%- set hash_alg = 'SHA2' -%}
-            {%- set unknown_key = "CONVERT(varchar(70), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varchar(70), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
-            {%- set hash_alg = 'SHA2_BINARY' -%}
-            {%- set unknown_key = "CONVERT(varbinary(64), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "CONVERT(varbinary(64), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(" ~ hash_datatype ~ ", '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(" ~ hash_datatype ~ ", 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%} 
     {%- endif -%}
 

--- a/macros/supporting/hash_default_values.sql
+++ b/macros/supporting/hash_default_values.sql
@@ -131,23 +131,33 @@
     {%- elif hash_function == 'SHA1' or hash_function == 'SHA1_HEX' or hash_function == 'SHA' -%} 
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
             {%- set hash_alg = 'SHA1' -%}
-            {%- set unknown_key = '!0000000000000000000000000000000000000000' -%}
-            {%- set error_key = '!ffffffffffffffffffffffffffffffffffffffff' -%}
+            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
             {%- set hash_alg = 'SHA1_BINARY' -%}
-            {%- set unknown_key = "TO_BINARY('0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(binary(20), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(binary(20), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}
-    {%- elif hash_function == 'SHA2' or hash_function == 'SHA2_HEX' -%}
+    {%- elif hash_function == 'SHA2' or hash_function == 'SHA2_HEX' or hash_function == 'SHA2_256' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
             {%- set hash_alg = 'SHA2' -%}
-            {%- set unknown_key = '!0000000000000000000000000000000000000000000000000000000000000000' -%}
-            {%- set error_key = '!ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' -%}
+            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
             {%- set hash_alg = 'SHA2_BINARY' -%}
-            {%- set unknown_key = "TO_BINARY('0000000000000000000000000000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(binary(32), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(binary(32), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}   
+    {%- elif hash_function == 'SHA2_512' -%}
+        {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
+            {%- set hash_alg = 'SHA2' -%}
+            {%- set unknown_key = "CONVERT(varchar(70), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varchar(70), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
+        {%- elif 'BINARY' in hash_datatype -%}
+            {%- set hash_alg = 'SHA2_BINARY' -%}
+            {%- set unknown_key = "CONVERT(binary(64), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(binary(64), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
+        {%- endif -%} 
     {%- endif -%}
 
     {%- do dict_result.update({"hash_alg": hash_alg, "unknown_key": unknown_key, "error_key": error_key }) -%}
@@ -180,23 +190,33 @@
     {%- elif hash_function == 'SHA1' or hash_function == 'SHA1_HEX' or hash_function == 'SHA' -%} 
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
             {%- set hash_alg = 'SHA1' -%}
-            {%- set unknown_key = '!0000000000000000000000000000000000000000' -%}
-            {%- set error_key = '!ffffffffffffffffffffffffffffffffffffffff' -%}
+            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
             {%- set hash_alg = 'SHA1_BINARY' -%}
-            {%- set unknown_key = "TO_BINARY('0000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(varbinary(20), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varbinary(20), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}
-    {%- elif hash_function == 'SHA2' or hash_function == 'SHA2_HEX' -%}
+    {%- elif hash_function == 'SHA2' or hash_function == 'SHA2_HEX' or hash_function == 'SHA2_256' -%}
         {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
             {%- set hash_alg = 'SHA2' -%}
-            {%- set unknown_key = '!0000000000000000000000000000000000000000000000000000000000000000' -%}
-            {%- set error_key = '!ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' -%}
+            {%- set unknown_key = "CONVERT(varchar(40), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varchar(40), 'ffffffffffffffffffffffffffffffffffffffff')" -%}
         {%- elif 'BINARY' in hash_datatype -%}
             {%- set hash_alg = 'SHA2_BINARY' -%}
-            {%- set unknown_key = "TO_BINARY('0000000000000000000000000000000000000000000000000000000000000000')" -%}
-            {%- set error_key = "TO_BINARY('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
+            {%- set unknown_key = "CONVERT(varbinary(32), '0000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varbinary(32), 'ffffffffffffffffffffffffffffffffffffffff')" -%}        
         {%- endif -%}   
+    {%- elif hash_function == 'SHA2_512' -%}
+        {%- if 'VARCHAR' in hash_datatype or 'CHAR' in hash_datatype or 'STRING' in hash_datatype or 'TEXT' in hash_datatype %}
+            {%- set hash_alg = 'SHA2' -%}
+            {%- set unknown_key = "CONVERT(varchar(70), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varchar(70), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}
+        {%- elif 'BINARY' in hash_datatype -%}
+            {%- set hash_alg = 'SHA2_BINARY' -%}
+            {%- set unknown_key = "CONVERT(varbinary(64), '0000000000000000000000000000000000000000000000000000000000000000')" -%}
+            {%- set error_key = "CONVERT(varbinary(64), 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')" -%}        
+        {%- endif -%} 
     {%- endif -%}
 
     {%- do dict_result.update({"hash_alg": hash_alg, "unknown_key": unknown_key, "error_key": error_key }) -%}

--- a/macros/supporting/hash_standardization.sql
+++ b/macros/supporting/hash_standardization.sql
@@ -407,7 +407,7 @@ CONCAT('\"', REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{ expr }}, r'\\', r'\\\\'), 
 
 {%- set zero_key = datavault4dbt.as_constant(column_str=zero_key) -%}
 
-{%- if not ('VARCHAR' in datatype or 'CHAR' in datatype or 'NVARCHAR' in datatype or 'NCHAR' in datatype) %}
+{%- if 'VARCHAR' in datatype or 'CHAR' in datatype or 'NVARCHAR' in datatype or 'NCHAR' in datatype %}
 
     {%- if case_sensitive -%}
     


### PR DESCRIPTION
# Description

  Fixes the hash algorithm configuration for the Microsoft Fabric adapter. The fabric__hash_default_values macro was updated to use T-SQL-compatible hash functions correctly: binary hash datatypes now use varbinary instead of binary (which is not supported in Fabric's T-SQL dialect the same way as Synapse).
  Additionally, the conditional branching logic was corrected to ensure the right hash algorithm is selected for each supported hash function (MD5, SHA1, SHA2, SHA2_512).

Fixes #(329) #(459)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Automatic tests (datavault4dbt-automatic-tests) against Microsoft Fabric

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
