### PR TITLE
fix: change datatypes to match allowed values

### DIFF
--- a/macros/internal/metadata_processing/metadata_processing.yml
+++ b/macros/internal/metadata_processing/metadata_processing.yml
@@ -11,7 +11,7 @@ macros:
         type: string
         description: The yaml-string that holds the definition of other parameters. Needs to be in yaml format. 
       - name: parameter
-        type: variable
+        type: string
         description: The forwarded parameter of the top-level macro. This is used, if the yaml-metadata is none. 
       - name: required
         type: boolean

--- a/macros/rehashing/single_entities/rehash_single_entities.yml
+++ b/macros/rehashing/single_entities/rehash_single_entities.yml
@@ -16,7 +16,7 @@ macros:
         type: string
         description: The name of the existing hashkey column.
       - name: business_keys
-        type: string or list
+        type: list
         description: The business key(s) used to calculate the new hash.
       - name: overwrite_hash_values
         type: boolean
@@ -43,7 +43,7 @@ macros:
         type: string
         description: The name of the existing hashkey column.
       - name: hash_config_dict
-        type: dictionary
+        type: dict[K,V]
         description: A dictionary containing the hash configuration.
 
   - name: rehash_single_link
@@ -116,7 +116,7 @@ macros:
         type: string
         description: The name of the existing hashdiff column.
       - name: ma_keys
-        type: string or list
+        type: list
         description: The multi-active key(s) of the satellite.
       - name: payload
         type: list
@@ -125,7 +125,7 @@ macros:
         type: string
         description: The name of the parent entity (hub or link).
       - name: business_keys
-        type: string or list
+        type: list
         description: The business key(s) of the parent entity.
       - name: overwrite_hash_values
         type: boolean
@@ -164,7 +164,7 @@ macros:
         type: string
         description: The load date timestamp column name.
       - name: hash_config_dict
-        type: dictionary
+        type: dict[K,V]
         description: A dictionary containing the hash configuration.
       - name: parent_relation
         type: relation
@@ -228,7 +228,7 @@ macros:
         type: relation
         description: The parent entity relation.
       - name: hash_config_dict
-        type: dictionary
+        type: dict[K,V]
         description: A dictionary containing the hash configuration.
 
   - name: rehash_single_satellite
@@ -288,7 +288,7 @@ macros:
         type: string
         description: The load date timestamp column name.
       - name: hash_config_dict
-        type: dictionary
+        type: dict[K,V]
         description: A dictionary containing the hash configuration.
       - name: parent_relation
         type: relation

--- a/macros/staging/staging.yml
+++ b/macros/staging/staging.yml
@@ -8,7 +8,7 @@ macros:
       When multiple columns are to be extracted from the same prejoin-target and with the same conditions(columns and operator) they will be combined into one item.
     arguments:
       - name: prejoined_columns
-        type: list or dictionary
+        type: list
         description: The value of the prejoined_columns as defined in the yaml_metadata of the stage-model.
 
   - name: extract_prejoin_column_names


### PR DESCRIPTION
# Description

Fusion gives  a couple of warnings, all regarding the parameter-datatypes defined in macro-yml files: 
```
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "hub_update_statement": argument "hash_config_dict" has unsupported type "dictionary". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "ma_satellite_update_statement": argument "hash_config_dict" has unsupported type "dictionary". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "nh_satellite_update_statement": argument "hash_config_dict" has unsupported type "dictionary". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/staging/staging.yml: Macro "process_prejoined_columns": argument "prejoined_columns" has unsupported type "list or dictionary". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "rehash_single_hub": argument "business_keys" has unsupported type "string or list". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "rehash_single_ma_satellite": argument "ma_keys" has unsupported type "string or list". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "rehash_single_ma_satellite": argument "business_keys" has unsupported type "string or list". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "rehash_single_nh_satellite": argument "business_keys" has unsupported type "string or list". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "rehash_single_satellite": argument "business_keys" has unsupported type "string or list". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/rehashing/single_entities/rehash_single_entities.yml: Macro "satellite_update_statement": argument "hash_config_dict" has unsupported type "dictionary". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
06:58:41 [warning] [ValidateMacroArgs (dbt1506)]: macros/internal/metadata_processing/metadata_processing.yml: Macro "yaml_metadata_parser": argument "parameter" has unsupported type "variable". Supported types are: string, str, boolean, bool, integer, int, float, any, relation, column, list[T], dict[K,V], optional[T], T1|T2|...
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
