### PR TITLE
Fix Delta Detection Logic for multi-batches

### DIFF
--- a/macros/tables/fabric/sat_v0.sql
+++ b/macros/tables/fabric/sat_v0.sql
@@ -137,7 +137,7 @@ deduplicated_numbered_source AS (
     {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
+        AND ({{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL)
 
     {%- set source_cte = 'deduplicated_numbered_source' -%}
 
@@ -166,9 +166,9 @@ records_to_insert AS (
         {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', 'sc'], condition='=') }}
         {%- endif %}
-            {%- if not source_is_single_batch and payload_count > 0 %}
+        {%- if not source_is_single_batch and payload_count > 0 %}
             AND sc.rn = 1
-            {%- endif %}
+        {%- endif %}
     )
     {%- endif %}
 

--- a/macros/tables/oracle/ref_sat_v0.sql
+++ b/macros/tables/oracle/ref_sat_v0.sql
@@ -122,12 +122,13 @@ deduplicated_numbered_source AS (
     {{ dedup_column }},
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , rn
+    {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
-        {% if is_incremental() -%}
-        AND rn = 1
-        {%- endif %}
+        AND ({{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL)
+
     {%- set last_cte = 'deduplicated_numbered_source' -%}
 ),
 {%- endif %}
@@ -158,7 +159,9 @@ records_to_insert AS (
             {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {%- endif %}
-            )
+            {%- if payload_count > 0 and not source_is_single_batch %}
+                AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/oracle/sat_v0.sql
+++ b/macros/tables/oracle/sat_v0.sql
@@ -122,12 +122,13 @@ deduplicated_numbered_source AS (
     {{ dedup_column }},
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , rn
+    {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
         AND ({{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL)
-        {% if is_incremental() -%}
-        AND rn = 1
-        {%- endif %}
+
     {%- set last_cte = 'deduplicated_numbered_source' -%}
 
 ),
@@ -153,6 +154,9 @@ records_to_insert AS (
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
         {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %}
+        {%- if payload_count > 0 and not source_is_single_batch %}
+            AND {{ last_cte }}.rn = 1
         {%- endif %})
     {%- endif %}
 

--- a/macros/tables/postgres/ref_sat_v0.sql
+++ b/macros/tables/postgres/ref_sat_v0.sql
@@ -121,12 +121,13 @@ deduplicated_numbered_source AS (
     {{ dedup_column }},
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , rn
+    {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
-        {% if is_incremental() -%}
-        AND rn = 1
-        {%- endif %}
+        AND ({{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL)
+
     {%- set last_cte = 'deduplicated_numbered_source' -%}
 ),
 {%- endif %}
@@ -157,7 +158,9 @@ records_to_insert AS (
             {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
             {%- endif %}
-            )
+            {%- if payload_count > 0 and not source_is_single_batch %}
+            AND {{ last_cte }}.rn = 1
+            {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/postgres/sat_v0.sql
+++ b/macros/tables/postgres/sat_v0.sql
@@ -122,12 +122,12 @@ deduplicated_numbered_source AS (
     {{ dedup_column }},
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , rn
+    {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE 1=1
-        AND {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
-        {% if is_incremental() -%}
-        AND rn = 1
-        {%- endif %}
+        AND ({{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL)
 
     {%- set last_cte = 'deduplicated_numbered_source' -%}
 
@@ -155,6 +155,9 @@ records_to_insert AS (
         WHERE {{ datavault4dbt.multikey(parent_hashkey, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
         {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', last_cte], condition='=') }}
+        {%- endif %}
+        {%- if payload_count > 0 and not source_is_single_batch %}
+            AND {{ last_cte }}.rn = 1
         {%- endif %})
     {%- endif %}
 

--- a/macros/tables/trino/ref_sat_v0.sql
+++ b/macros/tables/trino/ref_sat_v0.sql
@@ -120,7 +120,7 @@ deduplicated_numbered_source AS (
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
     {% if is_incremental() -%}
-    , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
+    , ROW_NUMBER() OVER(PARTITION BY {{ datavault4dbt.print_list(parent_ref_keys) }} ORDER BY {{ src_ldts }}) as rn
     {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
@@ -156,7 +156,7 @@ records_to_insert AS (
             {%- endif %}
         {%- if payload_count > 0 and not source_is_single_batch %}
             AND {{ source_cte }}.rn = 1
-        {%- endif %})            
+        {%- endif %})
     {%- endif %}
 
     )

--- a/macros/tables/trino/ref_sat_v0.sql
+++ b/macros/tables/trino/ref_sat_v0.sql
@@ -119,6 +119,9 @@ deduplicated_numbered_source AS (
     {{ dedup_column }},
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
+    {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
@@ -151,7 +154,9 @@ records_to_insert AS (
             {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
             {%- endif %}
-            )
+        {%- if payload_count > 0 and not source_is_single_batch %}
+            AND {{ source_cte }}.rn = 1
+        {%- endif %})            
     {%- endif %}
 
     )

--- a/macros/tables/trino/sat_v0.sql
+++ b/macros/tables/trino/sat_v0.sql
@@ -152,9 +152,7 @@ records_to_insert AS (
         {%- if payload_count > 0 and not source_is_single_batch %}
             AND {{ source_cte }}.rn = 1
         {%- endif %})
-    )
     {%- endif %}
-
     )
 
 SELECT * FROM records_to_insert

--- a/macros/tables/trino/sat_v0.sql
+++ b/macros/tables/trino/sat_v0.sql
@@ -116,6 +116,9 @@ deduplicated_numbered_source AS (
     {{ dedup_column }},
     {%- endif %}
     {{ datavault4dbt.print_list(source_cols) }}
+    {% if is_incremental() -%}
+    , ROW_NUMBER() OVER(PARTITION BY {{ parent_hashkey }} ORDER BY {{ src_ldts }}) as rn
+    {%- endif %}
     FROM deduplicated_numbered_source_prep
     WHERE {{ dedup_column }} <> prev_dedup_col OR prev_dedup_col IS NULL
 
@@ -146,6 +149,9 @@ records_to_insert AS (
         {%- if dedup_column is not none %}
             AND {{ datavault4dbt.multikey(dedup_column, prefix=['latest_entries_in_sat', source_cte], condition='=') }}
         {%- endif %}
+        {%- if payload_count > 0 and not source_is_single_batch %}
+            AND {{ source_cte }}.rn = 1
+        {%- endif %})
     )
     {%- endif %}
 


### PR DESCRIPTION
# Description

Incremental multi-batch processing was not properly inserting re-appearing hashdiffs (Trino, Oracle, Postgres)
This is now fixed.

Fixes #475 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
