### PR TITLE
fix: implement rehashing deprecated table helper macro for bigquery temp tables

### DIFF
--- a/macros/rehashing/internal_overwrites/rehash_relation_helpers.sql
+++ b/macros/rehashing/internal_overwrites/rehash_relation_helpers.sql
@@ -1,0 +1,52 @@
+{#
+    Helpers that keep the "_deprecated" copy of a rehashed entity consistent
+    across the rename, the CREATE ... FROM, and the final DROP.
+
+    Why this exists:
+        The rehash macros used to derive the deprecated copy with
+        make_temp_relation(rel, suffix='_deprecated'). make_temp_relation is
+        allowed to add uniqueness suffixes to the identifier (dbt-bigquery
+        >= 1.11.2 appends a %H%M%S%f timestamp), so the CREATE/DROP referenced a
+        different identifier than the plain "<identifier>_deprecated" produced by
+        the rename. The rehash then failed with
+        "Table ..._deprecated<timestamp> was not found".
+
+        rehash_deprecated_relation builds that identifier deterministically, and
+        rehash_prepare_rename performs the rename idempotently so an interrupted
+        prior run no longer wedges every following run with a 409 / "Already
+        Exists" or a leftover orphan.
+
+    Both helpers rely only on dbt built-ins (load_relation, run_query,
+    drop_table, get_rename_table_sql, Relation.incorporate), so they are
+    adapter-agnostic.
+#}
+
+{# Stable "<identifier>_deprecated" relation -- never routed through make_temp_relation. #}
+{% macro rehash_deprecated_relation(relation) %}
+    {{ return(relation.incorporate(path={"identifier": relation.identifier ~ '_deprecated'})) }}
+{% endmacro %}
+
+
+{# Rename `relation` to its _deprecated copy, recovering safely from an interrupted prior run.
+   Returns the deprecated relation so callers can reuse it for the CREATE FROM / DROP. #}
+{% macro rehash_prepare_rename(relation, output_logs=true) %}
+
+    {% set deprecated = datavault4dbt.rehash_deprecated_relation(relation) %}
+
+    {% if load_relation(deprecated) is not none %}
+        {% if load_relation(relation) is not none %}
+            {# Both exist: the _deprecated copy is a stale orphan, live data is in `relation`. #}
+            {{ log('Dropping stale deprecated table left by a previous run: ' ~ deprecated, output_logs) }}
+            {% do run_query(drop_table(deprecated)) %}
+        {% else %}
+            {# Only the _deprecated copy exists: a prior run died between rename and create. Recover it. #}
+            {{ log('Recovering ' ~ relation.identifier ~ ' from orphaned ' ~ deprecated.identifier ~ ' (interrupted prior run).', output_logs) }}
+            {% do run_query(get_rename_table_sql(deprecated, relation.identifier)) %}
+        {% endif %}
+    {% endif %}
+
+    {% do run_query(get_rename_table_sql(relation, deprecated.identifier)) %}
+
+    {{ return(deprecated) }}
+
+{% endmacro %}

--- a/macros/rehashing/single_entities/bigquery/rehash_single_hub.sql
+++ b/macros/rehashing/single_entities/bigquery/rehash_single_hub.sql
@@ -23,8 +23,8 @@
     {# Set Hash definition for new hashkey. #}
     {% set hash_config_dict = {new_hashkey_name: business_key_list} %}
 
-    {% set rename_sql = get_rename_table_sql(hub_relation, hub_relation.identifier ~ '_deprecated') %}
-    {% do run_query(rename_sql) %}
+    {# Rename to _deprecated, recovering safely if a previous run was interrupted. #}
+    {% set old_table_relation = datavault4dbt.rehash_prepare_rename(hub_relation, output_logs=output_logs) %}
 
     {# Get update SQL statement to calculate new hashkey. #}
     {% set create_sql = datavault4dbt.hub_update_statement(hub_relation=hub_relation,
@@ -39,10 +39,8 @@
     {{ log('CREATE statement completed!', output_logs) }}
 
     {% set columns_to_drop = [{"name": hashkey + '_deprecated'}]%}
-    
-    {% set old_table_relation = make_temp_relation(hub_relation,suffix='_deprecated') %}
 
-    {# Drop deprecated Hub table #}
+    {# Drop deprecated Hub table (old_table_relation set above by rehash_prepare_rename). #}
     {{ log('Dropping old table: ' ~ old_table_relation, output_logs) }}
     {% do run_query(drop_table(old_table_relation)) %}
     {% if drop_old_values %}
@@ -65,7 +63,7 @@
     {% set error_value_rsrc = var('datavault4dbt.default_error_rsrc', 'ERROR') %}
 
     {% set old_hashkey_name = hashkey + '_deprecated' %}
-    {% set old_table_relation = make_temp_relation(hub_relation,suffix='_deprecated') %}
+    {% set old_table_relation = datavault4dbt.rehash_deprecated_relation(hub_relation) %}
 
     
     {# Extract business keys from hash_config_dict, since business_key_list is not passed directly to the macro. #}

--- a/macros/rehashing/single_entities/bigquery/rehash_single_link.sql
+++ b/macros/rehashing/single_entities/bigquery/rehash_single_link.sql
@@ -49,8 +49,8 @@ dbt run-operation rehash_single_link --args '{link: customer_nation_l, link_hash
 
     {% endfor %}
 
-    {% set rename_sql = get_rename_table_sql(link_relation, link_relation.identifier ~ '_deprecated') %}
-    {% do run_query(rename_sql) %}
+    {# Rename to _deprecated, recovering safely if a previous run was interrupted. #}
+    {% set old_table_relation = datavault4dbt.rehash_prepare_rename(link_relation, output_logs=output_logs) %}
 
     {# generating the CREATE statement that populates the new columns. #}
     {% set create_sql = datavault4dbt.link_update_statement(link_relation=link_relation,
@@ -65,9 +65,7 @@ dbt run-operation rehash_single_link --args '{link: customer_nation_l, link_hash
     {% do run_query(create_sql) %}
     {{ log('UPDATE statement completed!', output_logs) }}
 
-    {# Drop deprecated table #}
-    {% set old_table_relation = make_temp_relation(link_relation,suffix='_deprecated') %}
-
+    {# Drop deprecated table (old_table_relation set above by rehash_prepare_rename). #}
     {{ log('Dropping old table: ' ~ old_table_relation, output_logs) }}
     {% do run_query(drop_table(old_table_relation)) %}
 
@@ -92,7 +90,7 @@ dbt run-operation rehash_single_link --args '{link: customer_nation_l, link_hash
     {% set error_value_rsrc = var('datavault4dbt.default_error_rsrc', 'ERROR') %}
 
     {% set old_link_hashkey_name = link_hashkey + '_deprecated'%}
-    {% set old_table_relation = make_temp_relation(link_relation,suffix='_deprecated') %}
+    {% set old_table_relation = datavault4dbt.rehash_deprecated_relation(link_relation) %}
 
 
 

--- a/macros/rehashing/single_entities/bigquery/rehash_single_ma_satellite.sql
+++ b/macros/rehashing/single_entities/bigquery/rehash_single_ma_satellite.sql
@@ -48,8 +48,8 @@
             } %}
 
 
-    {% set rename_sql = get_rename_table_sql(ma_satellite_relation, ma_satellite_relation.identifier ~ '_deprecated') %}
-    {% do run_query(rename_sql) %}
+    {# Rename to _deprecated, recovering safely if a previous run was interrupted. #}
+    {% set old_table_relation = datavault4dbt.rehash_prepare_rename(ma_satellite_relation, output_logs=output_logs) %}
 
     {# generating the CREATE statement that populates the new columns. #}
     {% set create_sql = datavault4dbt.ma_satellite_update_statement(ma_satellite_relation=ma_satellite_relation,
@@ -73,9 +73,7 @@
         {"name": hashdiff + '_deprecated'}
     ]%}
 
-
-    {% set old_table_relation = make_temp_relation(ma_satellite_relation,suffix='_deprecated') %}
-
+    {# old_table_relation set above by rehash_prepare_rename. #}
     {{ log('Dropping old table: ' ~ old_table_relation, output_logs) }}
     {% do run_query(drop_table(old_table_relation)) %}
 
@@ -95,7 +93,7 @@
     {% set ns = namespace(update_where_condition='', parent_already_rehashed=false) %}
     
     {% set old_hashkey_name = hashkey + '_deprecated' %}
-    {% set old_table_relation = make_temp_relation(ma_satellite_relation,suffix='_deprecated') %}
+    {% set old_table_relation = datavault4dbt.rehash_deprecated_relation(ma_satellite_relation) %}
 
     {% set prefixed_hashkey = 'src.' ~ hashkey %}
     {% set prefixed_ma_keys = datavault4dbt.prefix(columns=ma_keys, prefix_str='src').split(',') %}

--- a/macros/rehashing/single_entities/bigquery/rehash_single_nh_satellite.sql
+++ b/macros/rehashing/single_entities/bigquery/rehash_single_nh_satellite.sql
@@ -46,8 +46,8 @@
     {% endif %}
 
 
-    {% set rename_sql = get_rename_table_sql(nh_satellite_relation, nh_satellite_relation.identifier ~ '_deprecated') %}
-    {% do run_query(rename_sql) %}
+    {# Rename to _deprecated, recovering safely if a previous run was interrupted. #}
+    {% set old_table_relation = datavault4dbt.rehash_prepare_rename(nh_satellite_relation, output_logs=output_logs) %}
 
     {# generating the CREATE statement that populates the new columns. #}
     {% set create_sql = datavault4dbt.nh_satellite_update_statement(nh_satellite_relation=nh_satellite_relation,
@@ -67,8 +67,7 @@
         {"name": hashkey + '_deprecated'}
     ]%}
 
-    {% set old_table_relation = make_temp_relation(nh_satellite_relation,suffix='_deprecated') %}
-
+    {# old_table_relation set above by rehash_prepare_rename. #}
     {{ log('Dropping old table: ' ~ old_table_relation, output_logs) }}
     {% do run_query(drop_table(old_table_relation)) %}
 
@@ -88,7 +87,7 @@
     {% set ns = namespace(parent_already_rehashed=false) %}
     
     {% set old_hashkey_name = hashkey + '_deprecated' %}
-    {% set old_table_relation = make_temp_relation(nh_satellite_relation,suffix='_deprecated') %}
+    {% set old_table_relation = datavault4dbt.rehash_deprecated_relation(nh_satellite_relation) %}
     
     {#
         If parent entity is rehashed already (via rehash_all_rdv_entities macro), the "_deprecated"

--- a/macros/rehashing/single_entities/bigquery/rehash_single_satellite.sql
+++ b/macros/rehashing/single_entities/bigquery/rehash_single_satellite.sql
@@ -53,8 +53,8 @@
 
     {% endif %}
 
-    {% set rename_sql = get_rename_table_sql(satellite_relation, satellite_relation.identifier ~ '_deprecated') %}
-    {% do run_query(rename_sql) %}
+    {# Rename to _deprecated, recovering safely if a previous run was interrupted. #}
+    {% set old_table_relation = datavault4dbt.rehash_prepare_rename(satellite_relation, output_logs=output_logs) %}
 
     {# generating the CREATE statement that populates the new columns. #}
     {% set create_sql = datavault4dbt.satellite_update_statement(satellite_relation=satellite_relation,
@@ -75,9 +75,8 @@
         {"name": hashkey + '_deprecated'},
         {"name": hashdiff + '_deprecated'}
     ]%}
-        
-    {% set old_table_relation = make_temp_relation(satellite_relation,suffix='_deprecated') %}
 
+    {# old_table_relation set above by rehash_prepare_rename. #}
     {{ log('Dropping old table: ' ~ old_table_relation, output_logs) }}
     {% do run_query(drop_table(old_table_relation)) %}
 
@@ -96,7 +95,7 @@
     {% set ns = namespace(parent_already_rehashed=false) %}
     
     {% set old_hashkey_name = hashkey + '_deprecated' %}
-    {% set old_table_relation = make_temp_relation(satellite_relation,suffix='_deprecated') %}
+    {% set old_table_relation = datavault4dbt.rehash_deprecated_relation(satellite_relation) %}
     {#
         If parent entity is rehashed already (via rehash_all_rdv_entities macro), the "_deprecated"
         hashkey column needs to be used for joining, and the regular hashkey should be selected. 


### PR DESCRIPTION
# Description

An adapter update of dbt-bigquery (https://github.com/dbt-labs/dbt-adapters/pull/1360/changes) introduced the addition of timestamp-suffixes to created temp relations, leading to table-not-found errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Tests you ran

**Test Configuration**:
* datavault4dbt-Version:
* dbt-Version: _cloud/core, version number_
* dbt-adapter-Version:

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
