### PR TITLE
add ghost records to eff sat

### DIFF
--- a/macros/tables/bigquery/eff_sat_v0.sql
+++ b/macros/tables/bigquery/eff_sat_v0.sql
@@ -64,7 +64,8 @@ current_status AS (
         {{ is_active_alias }},
         {{ src_rsrc }}
     FROM {{ this }}
-    QUALIFY 
+    WHERE {{ src_ldts }} NOT IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
+    QUALIFY
         ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1
 
 ),
@@ -320,6 +321,18 @@ records_to_insert AS (
     {% endif %}
     ) disappeared_hashkeys
     {%- endif %}
+
+    UNION ALL
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
 
 )
 

--- a/macros/tables/databricks/eff_sat_v0.sql
+++ b/macros/tables/databricks/eff_sat_v0.sql
@@ -65,7 +65,8 @@ current_status AS (
         {{ is_active_alias }},
         {{ src_rsrc }}
     FROM {{ this }}
-    QUALIFY 
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
+    QUALIFY
         ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1
 
 ),
@@ -314,6 +315,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/exasol/eff_sat_v0.sql
+++ b/macros/tables/exasol/eff_sat_v0.sql
@@ -64,7 +64,8 @@ current_status AS (
         {{ is_active_alias }},
         {{ src_rsrc }}
     FROM {{ this }}
-    QUALIFY 
+    WHERE {{ src_ldts }} NOT IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
+    QUALIFY
         ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1
 
 ),
@@ -312,6 +313,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
 
 )
 

--- a/macros/tables/fabric/eff_sat_v0.sql
+++ b/macros/tables/fabric/eff_sat_v0.sql
@@ -72,6 +72,7 @@ current_status_prep AS (
         {{ src_rsrc }},
         ROW_NUMBER() OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
     FROM {{ this }}
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 ),
 
@@ -348,6 +349,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/oracle/eff_sat_v0.sql
+++ b/macros/tables/oracle/eff_sat_v0.sql
@@ -72,6 +72,7 @@ current_status_prep AS (
         {{ src_rsrc }},
         ROW_NUMBER() OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
     FROM {{ this }}
+    WHERE {{ src_ldts }} NOT IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
 
 ),
 
@@ -348,6 +349,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
 
 )
 

--- a/macros/tables/postgres/eff_sat_v0.sql
+++ b/macros/tables/postgres/eff_sat_v0.sql
@@ -72,6 +72,7 @@ current_status_prep AS (
         {{ src_rsrc }},
         ROW_NUMBER() OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
     FROM {{ this }}
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 ),
 
@@ -348,6 +349,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/redshift/eff_sat_v0.sql
+++ b/macros/tables/redshift/eff_sat_v0.sql
@@ -71,7 +71,8 @@ current_status AS (
         {{ is_active_alias }},
         {{ src_rsrc }}
     FROM {{ this }} redshift_requires_an_alias_if_the_qualify_is_directly_after_the_from
-    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1  
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1
 
 ),
 {% endif %}
@@ -318,6 +319,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/snowflake/eff_sat_v0.sql
+++ b/macros/tables/snowflake/eff_sat_v0.sql
@@ -70,6 +70,7 @@ current_status AS (
         {{ is_active_alias }},
         {{ src_rsrc }}
     FROM {{ this }}
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
     QUALIFY 
         ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) = 1
 
@@ -318,6 +319,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+        SELECT
+            {{ tracked_hashkey }},
+            {% for col in additional_columns -%}
+            {{ col }},
+            {% endfor -%}
+            {{ src_ldts }},
+            {{ src_rsrc }},
+            1 as {{ is_active_alias }}
+        FROM {{ source_relation }} src
+        WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/sqlserver/eff_sat_v0.sql
+++ b/macros/tables/sqlserver/eff_sat_v0.sql
@@ -72,6 +72,7 @@ current_status_prep AS (
         {{ src_rsrc }},
         ROW_NUMBER() OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
     FROM {{ this }}
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 ),
 
@@ -348,6 +349,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/synapse/eff_sat_v0.sql
+++ b/macros/tables/synapse/eff_sat_v0.sql
@@ -72,6 +72,7 @@ current_status_prep AS (
         {{ src_rsrc }},
         ROW_NUMBER() OVER (PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
     FROM {{ this }}
+    WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 ),
 
@@ -348,6 +349,18 @@ records_to_insert AS (
     FROM disappeared_hashkeys
 
     {%- endif %}
+
+    UNION
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
 
 )
 

--- a/macros/tables/trino/eff_sat_v0.sql
+++ b/macros/tables/trino/eff_sat_v0.sql
@@ -74,6 +74,7 @@ current_status AS (
             {{ src_rsrc }},
             ROW_NUMBER() OVER(PARTITION BY {{ tracked_hashkey }} ORDER BY {{ src_ldts }} DESC) as rn
         FROM {{ this }}
+        WHERE {{ src_ldts }} NOT IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
     ) t
     WHERE rn = 1
 
@@ -330,6 +331,18 @@ records_to_insert AS (
     {% endif %}
     ) disappeared_hashkeys
     {%- endif %}
+
+    UNION ALL
+    SELECT
+        {{ tracked_hashkey }},
+        {% for col in additional_columns -%}
+        {{ col }},
+        {% endfor -%}
+        {{ src_ldts }},
+        {{ src_rsrc }},
+        1 as {{ is_active_alias }}
+    FROM {{ source_relation }} src
+    WHERE {{ src_ldts }} IN ({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }}, {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }})
 
 )
 


### PR DESCRIPTION
# Description

Should only insert two additional Ghost Records to an effectivity Sat.

Would be nice it someone could verify it from a technical and logical perspective. Especially all other adapters than Snowflake.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)