### PR TITLE
fix(trino): ghost records and column capitalization in stages

### DIFF
--- a/macros/internal/metadata_processing/escape_column_names.sql
+++ b/macros/internal/metadata_processing/escape_column_names.sql
@@ -215,3 +215,15 @@
     {%- do return(escaped_column_name) -%}
 
 {%- endmacro -%}
+
+
+{%- macro trino__escape_column_name(column) -%}
+
+    {%- set escape_char_left  = var('escape_char_left',  '"') -%}
+    {%- set escape_char_right = var('escape_char_right', '"') -%}
+
+    {%- set escaped_column_name = escape_char_left ~ column | replace(escape_char_left, '') | replace(escape_char_right, '') | trim ~ escape_char_right | indent(4) -%}
+
+    {%- do return(escaped_column_name) -%}
+
+{%- endmacro -%}

--- a/macros/staging/trino/stage.sql
+++ b/macros/staging/trino/stage.sql
@@ -480,7 +480,7 @@ unknown_values AS (
     {%- if columns_without_excluded_columns is defined and columns_without_excluded_columns| length > 0 -%}
     {# Generating Ghost Records for all source columns, except the ldts, rsrc & edwSequence column #}
       {%- for column in columns_without_excluded_columns %}
-        ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.dtype, ghost_record_type='unknown') }}
+        ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.data_type, ghost_record_type='unknown') }}
       {%- endfor -%}
 
     {%- endif -%}
@@ -510,7 +510,7 @@ unknown_values AS (
               {%- set prejoin_extract_cols_lower = prejoin['extract_columns']|map('lower')|list -%}
               {%- set prejoin_col_index = prejoin_extract_cols_lower.index(column.name|lower) -%}
               {% if var('datavault4dbt.show_debug_logs', false) %}{{ log('column found? yes, for column: ' ~ column.name, false) }}{% endif %}
-              ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.dtype, ghost_record_type='unknown', alias=prejoin['aliases'][prejoin_col_index]) }}
+              ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.data_type, ghost_record_type='unknown', alias=prejoin['aliases'][prejoin_col_index]) }}
             {%- endif -%}
 
           {%- endfor -%}
@@ -546,7 +546,7 @@ error_values AS (
     {%- if columns_without_excluded_columns is defined and columns_without_excluded_columns| length > 0 -%}
     {# Generating Ghost Records for Source Columns #}
       {%- for column in columns_without_excluded_columns %}
-        ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.dtype, ghost_record_type='error') }}
+        ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.data_type, ghost_record_type='error') }}
       {%- endfor -%}
 
     {%- endif -%}
@@ -576,7 +576,7 @@ error_values AS (
               {%- set prejoin_extract_cols_lower = prejoin['extract_columns']|map('lower')|list -%}
               {%- set prejoin_col_index = prejoin_extract_cols_lower.index(column.name|lower) -%}
               {% if var('datavault4dbt.show_debug_logs', false) %}{{ log('column found? yes, for column: ' ~ column.name, false) }}{% endif %}
-             ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.dtype, ghost_record_type='error', alias=prejoin['aliases'][prejoin_col_index]) }}
+             ,{{ datavault4dbt.ghost_record_per_datatype(column_name=column.name, datatype=column.data_type, ghost_record_type='error', alias=prejoin['aliases'][prejoin_col_index]) }}
             {%- endif -%}
 
           {%- endfor -%}

--- a/macros/supporting/ghost_record_per_datatype.sql
+++ b/macros/supporting/ghost_record_per_datatype.sql
@@ -690,6 +690,8 @@
 
 {%- set unknown_value__STRING = var('datavault4dbt.unknown_value__STRING', '(unknown)') -%}
 {%- set error_value__STRING = var('datavault4dbt.error_value__STRING', '(error)') -%}
+{%- set unknown_value_alt__STRING = var('datavault4dbt.unknown_value_alt__STRING', 'u') -%}
+{%- set error_value_alt__STRING = var('datavault4dbt.error_value_alt__STRING', 'e') -%}
 
 {%- set hash_default_values = fromjson(datavault4dbt.hash_default_values(hash_function=datavault4dbt.hash_method())) -%}
 {%- set unknown_key = hash_default_values['unknown_key'] -%}
@@ -697,20 +699,44 @@
 
 {%- set datatype = datatype | string | upper | trim -%}
 
+{#- Extract the declared length of sized character types (e.g. VARCHAR(50) -> 50), if present. -#}
+{%- set char_length = none -%}
+{%- if (datatype.startswith('VARCHAR') or datatype.startswith('CHAR')) and '(' in datatype -%}
+    {%- set char_length = datatype.split('(')[1].split(')')[0] | int -%}
+{%- endif -%}
+
 {%- if ghost_record_type == 'unknown' -%}
         {%- if 'TIMESTAMP' in datatype %} CAST({{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }} AS {{ datatype }}) as {{ alias }}
         {%- elif datatype == 'DATE' %} CAST('{{ beginning_of_all_times_date }}' AS DATE) as {{ alias }}
-        {%- elif datatype in ['VARCHAR', 'STRING', 'TEXT'] %} '{{ unknown_value__STRING }}' as {{ alias }}
-        {%- elif datatype in ['INTEGER', 'INT', 'BIGINT', 'SMALLINT', 'TINYINT', 'DOUBLE', 'FLOAT', 'REAL', 'DECIMAL'] %} CAST({{ unknown_value__numeric }} as {{ datatype }}) as {{ alias }}
+        {%- elif datatype.startswith('TIME') -%}
+            {%- if 'WITH TIME ZONE' in datatype %} CAST('00:00:01+00:00' AS {{ datatype }}) as {{ alias }}
+            {%- else %} CAST('00:00:01' AS {{ datatype }}) as {{ alias }}
+            {%- endif -%}
+        {%- elif datatype.startswith('VARCHAR') or datatype.startswith('CHAR') -%}
+            {%- if char_length is not none and char_length < unknown_value__STRING | length %} CAST('{{ unknown_value_alt__STRING }}' as {{ datatype }}) as {{ alias }}
+            {%- else %} CAST('{{ unknown_value__STRING }}' as {{ datatype }}) as {{ alias }}
+            {%- endif -%}
+        {%- elif datatype in ['STRING', 'TEXT'] %} '{{ unknown_value__STRING }}' as {{ alias }}
+        {%- elif datatype.startswith('DECIMAL') or datatype in ['INTEGER', 'INT', 'BIGINT', 'SMALLINT', 'TINYINT', 'DOUBLE', 'FLOAT', 'REAL'] %} CAST({{ unknown_value__numeric }} as {{ datatype }}) as {{ alias }}
         {%- elif datatype == 'BOOLEAN' %} CAST(FALSE as BOOLEAN) as {{ alias }}
+        {%- elif 'BINARY' in datatype %} from_hex({{ datavault4dbt.as_constant(column_str=unknown_key) }}) as {{ alias }}
         {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
         {% endif %}
 {%- elif ghost_record_type == 'error' -%}
         {%- if 'TIMESTAMP' in datatype %} CAST({{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }} AS {{ datatype }}) as {{ alias }}
         {%- elif datatype == 'DATE' %} CAST('{{ end_of_all_times_date }}' AS DATE) as {{ alias }}
-        {%- elif datatype in ['VARCHAR', 'STRING', 'TEXT'] %} '{{ error_value__STRING }}' as {{ alias }}
-        {%- elif datatype in ['INTEGER', 'INT', 'BIGINT', 'SMALLINT', 'TINYINT', 'DOUBLE', 'FLOAT', 'REAL', 'DECIMAL'] %} CAST({{ error_value__numeric }} as {{ datatype }}) as {{ alias }}
+        {%- elif datatype.startswith('TIME') -%}
+            {%- if 'WITH TIME ZONE' in datatype %} CAST('23:59:59+00:00' AS {{ datatype }}) as {{ alias }}
+            {%- else %} CAST('23:59:59' AS {{ datatype }}) as {{ alias }}
+            {%- endif -%}
+        {%- elif datatype.startswith('VARCHAR') or datatype.startswith('CHAR') -%}
+            {%- if char_length is not none and char_length < error_value__STRING | length %} CAST('{{ error_value_alt__STRING }}' as {{ datatype }}) as {{ alias }}
+            {%- else %} CAST('{{ error_value__STRING }}' as {{ datatype }}) as {{ alias }}
+            {%- endif -%}
+        {%- elif datatype in ['STRING', 'TEXT'] %} '{{ error_value__STRING }}' as {{ alias }}
+        {%- elif datatype.startswith('DECIMAL') or datatype in ['INTEGER', 'INT', 'BIGINT', 'SMALLINT', 'TINYINT', 'DOUBLE', 'FLOAT', 'REAL'] %} CAST({{ error_value__numeric }} as {{ datatype }}) as {{ alias }}
         {%- elif datatype == 'BOOLEAN' %} CAST(FALSE as BOOLEAN) as {{ alias }}
+        {%- elif 'BINARY' in datatype %} from_hex({{ datavault4dbt.as_constant(column_str=error_key) }}) as {{ alias }}
         {%- else %} CAST(NULL as {{ datatype }}) as {{ alias }}
         {% endif %}
 {%- else -%}


### PR DESCRIPTION
# Description

Trino ghost records were enhanced to take varchar length as well as decimal precision into account.

Additionally the column-names in the stage-macro are not capitalized anymore.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)