### PR TITLE
New global variables for clocktick setting (unit and step_size)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -71,6 +71,10 @@ vars:
   datavault4dbt.stg_default_dtype: {"bigquery":"STRING","snowflake":"VARCHAR", "exasol": "VARCHAR (2000000) UTF8", "postgres": "VARCHAR", "redshift": "VARCHAR", "synapse": "VARCHAR", "fabric": "VARCHAR(255)", "oracle":"VARCHAR2(40)", databricks: "STRING", trino: "VARCHAR", "sqlserver": "VARCHAR(255)"}
   datavault4dbt.derived_columns_default_dtype: {"bigquery":"STRING","snowflake":"VARCHAR", "exasol": "VARCHAR (2000000) UTF8", "postgres": "VARCHAR", "redshift": "VARCHAR", "synapse": "VARCHAR", "fabric": "VARCHAR(255)", "oracle":"VARCHAR2(40)", databricks: "STRING", trino: "VARCHAR", "sqlserver": "VARCHAR(255)"}
 
+  #Clocktick Settings
+  datavault4dbt.clocktick_unit: {"bigquery":"SECOND","snowflake":"SECOND", "exasol": "SECOND", "postgres": "SECOND", "redshift": "SECOND", "synapse": "SECOND", "fabric": "MICROSECOND", "oracle":"SECOND", "databricks": "SECOND", "trino": "SECOND", "sqlserver": "SECOND"}
+  datavault4dbt.clocktick_step_size: '1'
+
   #Datatype specific default values
   datavault4dbt.error_value__STRING: '(error)'
   datavault4dbt.error_value_alt__STRING: 'e'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -72,7 +72,7 @@ vars:
   datavault4dbt.derived_columns_default_dtype: {"bigquery":"STRING","snowflake":"VARCHAR", "exasol": "VARCHAR (2000000) UTF8", "postgres": "VARCHAR", "redshift": "VARCHAR", "synapse": "VARCHAR", "fabric": "VARCHAR(255)", "oracle":"VARCHAR2(40)", databricks: "STRING", trino: "VARCHAR", "sqlserver": "VARCHAR(255)"}
 
   #Clocktick Settings
-  datavault4dbt.clocktick_unit: {"bigquery":"SECOND","snowflake":"SECOND", "exasol": "SECOND", "postgres": "SECOND", "redshift": "SECOND", "synapse": "SECOND", "fabric": "MICROSECOND", "oracle":"SECOND", "databricks": "SECOND", "trino": "SECOND", "sqlserver": "SECOND"}
+  datavault4dbt.clocktick_unit: {"bigquery":"MICROSECOND","snowflake":"MICROSECOND", "exasol": "MILLISECOND", "postgres": "MICROSECOND", "redshift": "MICROSECOND", "synapse": "NANOSECOND", "fabric": "MICROSECOND", "oracle":"MICROSECOND", "databricks": "MICROSECOND", "trino": "MILLISECOND", "sqlserver": "NANOSECOND"}
   datavault4dbt.clocktick_step_size: '1'
 
   #Datatype specific default values

--- a/docs/26_general-usage-notes/29_global-variables/29_global-variables.md
+++ b/docs/26_general-usage-notes/29_global-variables/29_global-variables.md
@@ -88,6 +88,15 @@ All the following variables are **prefixed with `datavault4dbt`**.
 | stg_default_dtype              | Record Tracking Satellite     | The default datatype for the `stg_alias` column inside a record tracking satellite. |
 | derived_columns_default_dtype  | Stage                         | The default datatype for derived columns, if no other datatype can be detected automatically. |
 
+### CLOCKTICK CONFIGURATION
+
+| Name                           | Usage                         | Explanation |
+|--------------------------------|-------------------------------|-------------|
+| clocktick_unit                 | v1- & pit-macros                         | The unit of time used for clocktick operations (e.g. the unit of time that is subtracted when calculating the end-ldts based on the "next" ldts for the corresponding hashkey in a satellite). |
+| clocktick_step_size            | v1- & pit-macros                         | The step size used for clocktick operations described above. |
+
+It is advised that the format of your ldts corresponds to the chosen clocktick settings. For example, if your ldts is a timestamp with the granularity of seconds, you should set your clocktick to 1 second. 
+
 ### DATATYPE SPECIFIC DEFAULT VALUES
 
 For each datatype there is a default unknown and error value defined. Additionally, an alternative, usually much shorter value is defined. See the applied default values in the table below.

--- a/macros/supporting/clocktick_unit.sql
+++ b/macros/supporting/clocktick_unit.sql
@@ -1,0 +1,281 @@
+{%- macro clocktick_unit() %}
+
+    {{ return( adapter.dispatch('clocktick_unit', 'datavault4dbt')() ) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'bigquery' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['bigquery'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro snowflake__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'snowflake' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['snowflake'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro exasol__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'exasol' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['exasol'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (exasol) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro synapse__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}    
+    {%- if 'synapse' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['synapse'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (synapse) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}        
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}  
+
+
+{%- macro postgres__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'postgres' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['postgres'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (postgres) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro redshift__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'redshift' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['redshift'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (redshift) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro fabric__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}    
+    {%- if 'fabric' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['fabric'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (fabric) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "MICROSECOND" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro oracle__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'oracle' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['oracle'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (Oracle) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro databricks__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'databricks' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['databricks'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (databricks) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+
+{%- macro trino__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'trino' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['trino'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (trino) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {%- endif -%}
+{%- else -%}
+    {%- if global_var is not none -%}
+        {%- set clocktick_unit = global_var -%}
+    {%- else -%}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {%- endif -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}
+
+{%- macro sqlserver__clocktick_unit() %}
+
+{%- set global_var = var('datavault4dbt.clocktick_unit', none) -%}
+{%- set clocktick_unit = '' -%}
+
+{%- if global_var is mapping -%}
+    {%- if 'sqlserver' in global_var.keys()|map('lower') -%}
+        {% set clocktick_unit = global_var['sqlserver'] %}
+    {%- else -%}
+        {%- if execute -%}
+            {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (sqlserver) as a key. Applying the default value.") -%}
+        {% endif %}
+        {%- set clocktick_unit = "SECONDS" -%}
+    {% endif %}
+{%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
+    {%- set clocktick_unit = global_var -%}
+{%- else -%}
+    {%- set clocktick_unit = "SECONDS" -%}
+{%- endif -%}
+
+{{ return(clocktick_unit) }}
+
+{%- endmacro -%}

--- a/macros/supporting/clocktick_unit.sql
+++ b/macros/supporting/clocktick_unit.sql
@@ -11,8 +11,8 @@
 {%- set clocktick_unit = '' -%}
 
 {%- if global_var is mapping -%}
-    {%- if 'bigquery' in global_var.keys()|map('lower') -%}
-        {% set clocktick_unit = global_var['bigquery'] %}
+    {%- if global_var.get('bigquery') is not none -%}
+        {% set clocktick_unit = global_var.get('bigquery') %}
     {%- else -%}
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}

--- a/macros/supporting/clocktick_unit.sql
+++ b/macros/supporting/clocktick_unit.sql
@@ -245,7 +245,7 @@
         {%- set clocktick_unit = "MILLISECOND" -%}
     {%- endif -%}
 {%- else -%}
-    {%- if global_var is not none -%}
+    {%- if datavault4dbt.is_something(global_var) -%}
         {%- set clocktick_unit = global_var -%}
     {%- else -%}
         {%- set clocktick_unit = "MILLISECOND" -%}

--- a/macros/supporting/clocktick_unit.sql
+++ b/macros/supporting/clocktick_unit.sql
@@ -17,12 +17,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (bigquery) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MICROSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -42,12 +42,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (snowflake) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MICROSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -67,12 +67,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (exasol) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MILLISECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MILLISECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -92,12 +92,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (synapse) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "NANOSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}        
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "NANOSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -117,12 +117,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (postgres) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MICROSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -142,12 +142,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (redshift) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MICROSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -192,12 +192,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (Oracle) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MICROSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -217,12 +217,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (databricks) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MICROSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "MICROSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}
@@ -242,13 +242,13 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (trino) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MILLISECOND" -%}
     {%- endif -%}
 {%- else -%}
     {%- if global_var is not none -%}
         {%- set clocktick_unit = global_var -%}
     {%- else -%}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "MILLISECOND" -%}
     {%- endif -%}
 {%- endif -%}
 
@@ -268,12 +268,12 @@
         {%- if execute -%}
             {%- do exceptions.warn("Warning: You have set the global variable 'datavault4dbt.clocktick_unit' to a dictionary, but have not included the adapter you use (sqlserver) as a key. Applying the default value.") -%}
         {% endif %}
-        {%- set clocktick_unit = "SECONDS" -%}
+        {%- set clocktick_unit = "NANOSECOND" -%}
     {% endif %}
 {%- elif global_var is not mapping and datavault4dbt.is_something(global_var) -%}
     {%- set clocktick_unit = global_var -%}
 {%- else -%}
-    {%- set clocktick_unit = "SECONDS" -%}
+    {%- set clocktick_unit = "NANOSECOND" -%}
 {%- endif -%}
 
 {{ return(clocktick_unit) }}

--- a/macros/supporting/subtract_clocktick.sql
+++ b/macros/supporting/subtract_clocktick.sql
@@ -1,0 +1,145 @@
+{%- macro subtract_clocktick(timestamp_expression) -%}
+
+    {{ return(adapter.dispatch('subtract_clocktick', 'datavault4dbt')(timestamp_expression)) }}
+
+{%- endmacro -%}
+
+
+{%- macro default__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+TIMESTAMP_SUB({{ timestamp_expression }}, INTERVAL {{ clocktick_step_size }} {{ clocktick_unit }})
+
+{%- endmacro -%}
+
+
+{%- macro snowflake__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expression }})
+
+{%- endmacro -%}
+
+
+{%- macro exasol__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+{%- if clocktick_unit == 'MICROSECOND' -%}
+ADD_SECONDS({{ timestamp_expression }}, -({{ clocktick_step_size }} / 1000000.0))
+{%- elif clocktick_unit == 'MILLISECOND' -%}
+ADD_SECONDS({{ timestamp_expression }}, -({{ clocktick_step_size }} / 1000.0))
+{%- elif clocktick_unit == 'SECOND' -%}
+ADD_SECONDS({{ timestamp_expression }}, -{{ clocktick_step_size }})
+{%- elif clocktick_unit == 'MINUTE' -%}
+ADD_MINUTES({{ timestamp_expression }}, -{{ clocktick_step_size }})
+{%- elif clocktick_unit == 'HOUR' -%}
+ADD_HOURS({{ timestamp_expression }}, -{{ clocktick_step_size }})
+{%- elif clocktick_unit == 'DAY' -%}
+ADD_DAYS({{ timestamp_expression }}, -{{ clocktick_step_size }})
+{%- else -%}
+    {%- do exceptions.raise_compiler_error("Unsupported value '" ~ clocktick_unit ~ "' for datavault4dbt.clocktick_unit on Exasol. Supported values are MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, and DAY.") -%}
+{%- endif -%}
+
+{%- endmacro -%}
+
+
+{%- macro synapse__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- if clocktick_unit == 'NANOSECOND' -%}
+    {%- set clocktick_step_size = max(var('datavault4dbt.clocktick_step_size', '1'), 100) -%}
+{%- else -%}
+    {%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+{%- endif -%}
+
+DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expression }})
+
+{%- endmacro -%}
+
+
+{%- macro postgres__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | lower -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+{{ timestamp_expression }} - CAST('{{ clocktick_step_size }} {{ clocktick_unit }}' AS INTERVAL)
+
+{%- endmacro -%}
+
+
+{%- macro redshift__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expression }})
+
+{%- endmacro -%}
+
+
+{%- macro fabric__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expression }})
+
+{%- endmacro -%}
+
+
+{%- macro oracle__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+{%- if clocktick_unit == 'MICROSECOND' -%}
+{{ timestamp_expression }} - NUMTODSINTERVAL({{ clocktick_step_size }} / 1000000.0, 'SECOND')
+{%- elif clocktick_unit == 'MILLISECOND' -%}
+{{ timestamp_expression }} - NUMTODSINTERVAL({{ clocktick_step_size }} / 1000.0, 'SECOND')
+{%- elif clocktick_unit in ['SECOND', 'MINUTE', 'HOUR', 'DAY'] -%}
+{{ timestamp_expression }} - NUMTODSINTERVAL({{ clocktick_step_size }}, '{{ clocktick_unit }}')
+{%- else -%}
+    {%- do exceptions.raise_compiler_error("Unsupported value '" ~ clocktick_unit ~ "' for datavault4dbt.clocktick_unit on Oracle. Supported values are MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, and DAY.") -%}
+{%- endif -%}
+
+{%- endmacro -%}
+
+
+{%- macro databricks__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+TRY_SUBTRACT({{ timestamp_expression }}, INTERVAL {{ clocktick_step_size }} {{ clocktick_unit }})
+
+{%- endmacro -%}
+
+
+{%- macro trino__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | lower -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+
+date_add('{{ clocktick_unit }}', -{{ clocktick_step_size }}, {{ timestamp_expression }})
+
+{%- endmacro -%}
+
+
+{%- macro sqlserver__subtract_clocktick(timestamp_expression) -%}
+
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
+{%- if clocktick_unit == 'NANOSECOND' -%}
+    {%- set clocktick_step_size = max(var('datavault4dbt.clocktick_step_size', '1'), 100) -%}
+{%- else -%}
+    {%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+{%- endif -%}
+
+DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expression }})
+
+{%- endmacro -%}

--- a/macros/supporting/subtract_clocktick.sql
+++ b/macros/supporting/subtract_clocktick.sql
@@ -52,8 +52,8 @@ ADD_DAYS({{ timestamp_expression }}, -{{ clocktick_step_size }})
 {%- macro synapse__subtract_clocktick(timestamp_expression) -%}
 
 {%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
-{%- if clocktick_unit == 'NANOSECOND' -%}
-    {%- set clocktick_step_size = max(var('datavault4dbt.clocktick_step_size', '1'), 100) -%}
+{%- if clocktick_unit == 'NANOSECOND' and var('datavault4dbt.clocktick_step_size', '1')|int < 100 -%}
+    {%- set clocktick_step_size = 100 -%}
 {%- else -%}
     {%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 {%- endif -%}
@@ -86,7 +86,11 @@ DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expressio
 {%- macro fabric__subtract_clocktick(timestamp_expression) -%}
 
 {%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
-{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+{%- if clocktick_unit == 'NANOSECOND' and var('datavault4dbt.clocktick_step_size', '1')|int < 1000 -%}
+    {%- set clocktick_step_size = 1000 -%}
+{%- else -%}
+    {%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
+{%- endif -%}
 
 DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ timestamp_expression }})
 
@@ -134,8 +138,8 @@ date_add('{{ clocktick_unit }}', -{{ clocktick_step_size }}, {{ timestamp_expres
 {%- macro sqlserver__subtract_clocktick(timestamp_expression) -%}
 
 {%- set clocktick_unit = datavault4dbt.clocktick_unit() | upper -%}
-{%- if clocktick_unit == 'NANOSECOND' -%}
-    {%- set clocktick_step_size = max(var('datavault4dbt.clocktick_step_size', '1'), 100) -%}
+{%- if clocktick_unit == 'NANOSECOND' and var('datavault4dbt.clocktick_step_size', '1')|int < 100 -%}
+    {%- set clocktick_step_size = 100 -%}
 {%- else -%}
     {%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 {%- endif -%}

--- a/macros/tables/bigquery/ma_sat_v1.sql
+++ b/macros/tables/bigquery/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/bigquery/pit.sql
+++ b/macros/tables/bigquery/pit.sql
@@ -85,7 +85,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(TIMESTAMP_SUB({{ ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/bigquery/ref_sat_v1.sql
+++ b/macros/tables/bigquery/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/bigquery/sat_v1.sql
+++ b/macros/tables/bigquery/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(TIMESTAMP_SUB({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if include_payload -%},
             {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/databricks/ma_sat_v1.sql
+++ b/macros/tables/databricks/ma_sat_v1.sql
@@ -49,7 +49,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/databricks/pit.sql
+++ b/macros/tables/databricks/pit.sql
@@ -91,7 +91,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(({{ldts}} - INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/databricks/ref_sat_v1.sql
+++ b/macros/tables/databricks/ref_sat_v1.sql
@@ -43,7 +43,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/databricks/sat_v1.sql
+++ b/macros/tables/databricks/sat_v1.sql
@@ -39,7 +39,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(TRY_SUBTRACT({{ src_ldts }}, INTERVAL 1 MICROSECOND)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if include_payload -%},
             {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/exasol/ma_sat_v1.sql
+++ b/macros/tables/exasol/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/exasol/pit.sql
+++ b/macros/tables/exasol/pit.sql
@@ -81,7 +81,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(ADD_SECONDS({{ ldts }}, -0.001)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/exasol/ref_sat_v1.sql
+++ b/macros/tables/exasol/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/exasol/sat_v1.sql
+++ b/macros/tables/exasol/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(ADD_SECONDS({{ src_ldts }}, -0.001)) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp( timestamp_format , end_of_all_times) }}) as {{ ledts_alias }}
         {%- if include_payload -%},
             {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/fabric/ma_sat_v1.sql
+++ b/macros/tables/fabric/ma_sat_v1.sql
@@ -2,6 +2,8 @@
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
@@ -51,7 +53,7 @@ end_dated_loads AS (
     {{ hashkey }},
     {{ src_ldts }},
     COALESCE(
-        DATEADD(MICROSECOND, -1, LEAD({{ src_ldts }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }})),
+        DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, LEAD({{ src_ldts }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }})),
         CAST('{{ end_of_all_times }}' AS DATETIME2(6))
     ) AS {{ ledts_alias }}
 FROM distinct_hk_ldts

--- a/macros/tables/fabric/ma_sat_v1.sql
+++ b/macros/tables/fabric/ma_sat_v1.sql
@@ -2,8 +2,6 @@
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
-{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
-{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
@@ -53,7 +51,7 @@ end_dated_loads AS (
     {{ hashkey }},
     {{ src_ldts }},
     COALESCE(
-        DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, LEAD({{ src_ldts }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }})),
+        LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),
         CAST('{{ end_of_all_times }}' AS DATETIME2(6))
     ) AS {{ ledts_alias }}
 FROM distinct_hk_ldts

--- a/macros/tables/fabric/pit.sql
+++ b/macros/tables/fabric/pit.sql
@@ -6,8 +6,6 @@
 {%- set hash_alg = hash_default_values['hash_alg'] -%}
 {%- set unknown_key = hash_default_values['unknown_key'] -%}
 {%- set error_key = hash_default_values['error_key'] -%}
-{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
-{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set rsrc = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
 {%- set rsrc = datavault4dbt.escape_column_names(rsrc) -%}
@@ -89,7 +87,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/fabric/pit.sql
+++ b/macros/tables/fabric/pit.sql
@@ -6,6 +6,8 @@
 {%- set hash_alg = hash_default_values['hash_alg'] -%}
 {%- set unknown_key = hash_default_values['unknown_key'] -%}
 {%- set error_key = hash_default_values['error_key'] -%}
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set rsrc = var('datavault4dbt.rsrc_alias', 'rsrc') -%}
 {%- set rsrc = datavault4dbt.escape_column_names(rsrc) -%}
@@ -87,7 +89,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(DATEADD(MICROSECOND, -1, {{ ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD(DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/fabric/ref_sat_v1.sql
+++ b/macros/tables/fabric/ref_sat_v1.sql
@@ -2,6 +2,8 @@
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
@@ -43,7 +45,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(MICROSECOND, -1, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD(DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/fabric/ref_sat_v1.sql
+++ b/macros/tables/fabric/ref_sat_v1.sql
@@ -2,8 +2,6 @@
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
-{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
-{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
@@ -45,7 +43,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/fabric/sat_v1.sql
+++ b/macros/tables/fabric/sat_v1.sql
@@ -2,8 +2,6 @@
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
-{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
-{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
@@ -42,7 +40,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
        {%- if include_payload and source_columns_to_select | length >= 1 -%} , {% endif -%}
         {%- if include_payload -%}{{ datavault4dbt.print_list(source_columns_to_select) }}{%- endif -%}
     FROM {{ source_relation }}

--- a/macros/tables/fabric/sat_v1.sql
+++ b/macros/tables/fabric/sat_v1.sql
@@ -2,6 +2,8 @@
 
 {%- set end_of_all_times = datavault4dbt.end_of_all_times() -%}
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
+{%- set clocktick_unit = datavault4dbt.clocktick_unit() -%}
+{%- set clocktick_step_size = var('datavault4dbt.clocktick_step_size', '1') -%}
 
 {%- set is_current_col_alias = var('datavault4dbt.is_current_col_alias', 'IS_CURRENT') -%}
 {%- set is_current_col_alias = datavault4dbt.escape_column_names(is_current_col_alias) -%}
@@ -40,7 +42,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(MICROSECOND, -1, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD(DATEADD({{ clocktick_unit }}, -{{ clocktick_step_size }}, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
        {%- if include_payload and source_columns_to_select | length >= 1 -%} , {% endif -%}
         {%- if include_payload -%}{{ datavault4dbt.print_list(source_columns_to_select) }}{%- endif -%}
     FROM {{ source_relation }}

--- a/macros/tables/oracle/ma_sat_v1.sql
+++ b/macros/tables/oracle/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/oracle/pit.sql
+++ b/macros/tables/oracle/pit.sql
@@ -81,7 +81,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD({{ ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/oracle/ref_sat_v1.sql
+++ b/macros/tables/oracle/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/oracle/sat_v1.sql
+++ b/macros/tables/oracle/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.000001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if include_payload -%},
             {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) if source_columns_to_select else " *" }}
         {%- endif %}

--- a/macros/tables/postgres/ma_sat_v1.sql
+++ b/macros/tables/postgres/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/postgres/pit.sql
+++ b/macros/tables/postgres/pit.sql
@@ -85,7 +85,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD({{ ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/postgres/ref_sat_v1.sql
+++ b/macros/tables/postgres/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/postgres/sat_v1.sql
+++ b/macros/tables/postgres/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - interval '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if include_payload -%},
             {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/redshift/ma_sat_v1.sql
+++ b/macros/tables/redshift/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/redshift/pit.sql
+++ b/macros/tables/redshift/pit.sql
@@ -76,7 +76,7 @@ FROM {{ ref(tracked_entity) }} te
             {{ hashkey }},
             {{ ldts }},
             COALESCE(
-                LEAD({{ ldts }} - interval '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),
+                LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),
                 {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
             ) AS {{ ledts }}
         FROM {{ ref(satellite) }}

--- a/macros/tables/redshift/ref_sat_v1.sql
+++ b/macros/tables/redshift/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }}- INTERVAL '00:00:00.000001') OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/redshift/sat_v1.sql
+++ b/macros/tables/redshift/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - interval '00:00:00.000001') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if include_payload -%},
             {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/snowflake/ma_sat_v1.sql
+++ b/macros/tables/snowflake/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/snowflake/pit.sql
+++ b/macros/tables/snowflake/pit.sql
@@ -129,7 +129,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD({{ ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/snowflake/ref_sat_v1.sql
+++ b/macros/tables/snowflake/ref_sat_v1.sql
@@ -31,7 +31,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ datavault4dbt.print_list(datavault4dbt.escape_column_names(ref_keys)) }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) }}
         {%- endif %}

--- a/macros/tables/snowflake/sat_v1.sql
+++ b/macros/tables/snowflake/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '1 MICROSECOND') OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if include_payload -%},
             {{- "\n\n    " ~ datavault4dbt.print_list(datavault4dbt.escape_column_names(source_columns_to_select)) if source_columns_to_select else " *" }}
         {%- endif %}

--- a/macros/tables/sqlserver/ma_sat_v1.sql
+++ b/macros/tables/sqlserver/ma_sat_v1.sql
@@ -51,7 +51,7 @@ end_dated_loads AS (
     {{ hashkey }},
     {{ src_ldts }},
     COALESCE(
-        DATEADD(ns, -100, LEAD({{ src_ldts }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }})),
+        LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),
         CAST('{{ end_of_all_times }}' AS {{ datavault4dbt.timestamp_default_dtype() }})
     ) AS {{ ledts_alias }}
 FROM distinct_hk_ldts

--- a/macros/tables/sqlserver/pit.sql
+++ b/macros/tables/sqlserver/pit.sql
@@ -87,7 +87,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(DATEADD(ns, -100, {{ ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/sqlserver/ref_sat_v1.sql
+++ b/macros/tables/sqlserver/ref_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/sqlserver/sat_v1.sql
+++ b/macros/tables/sqlserver/sat_v1.sql
@@ -37,7 +37,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
        {%- if include_payload and source_columns_to_select | length >= 1 -%} , {% endif -%}
         {%- if include_payload -%}{{ datavault4dbt.print_list(source_columns_to_select) }}{%- endif -%}
     FROM {{ source_relation }}

--- a/macros/tables/synapse/ma_sat_v1.sql
+++ b/macros/tables/synapse/ma_sat_v1.sql
@@ -42,7 +42,7 @@ end_dated_loads AS (
     {{ hashkey }},
     {{ src_ldts }},
     COALESCE(
-        DATEADD(ns, -100, LEAD({{ src_ldts }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }})),
+        LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),
         CAST('{{ end_of_all_times }}' AS DATETIME2)
     ) AS {{ ledts_alias }}
 FROM distinct_hk_ldts

--- a/macros/tables/synapse/pit.sql
+++ b/macros/tables/synapse/pit.sql
@@ -81,7 +81,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD(DATEADD(ns, -100, {{ ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/synapse/ref_sat_v1.sql
+++ b/macros/tables/synapse/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/synapse/sat_v1.sql
+++ b/macros/tables/synapse/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD(DATEADD(ns, -100, {{ src_ldts }})) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts_alias }}
         {%- if include_payload and source_columns_to_select | length >= 1 -%}
         ,{{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/trino/ma_sat_v1.sql
+++ b/macros/tables/trino/ma_sat_v1.sql
@@ -41,7 +41,7 @@ end_dated_loads AS (
     SELECT
         {{ hashkey }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format,end_of_all_times) }}) as {{ ledts_alias }}
     FROM distinct_hk_ldts
 
 ),

--- a/macros/tables/trino/pit.sql
+++ b/macros/tables/trino/pit.sql
@@ -80,7 +80,7 @@ pit_records AS (
             SELECT
                 {{ hashkey }},
                 {{ ldts }},
-                COALESCE(LEAD({{ ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
+                COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) AS {{ ledts }}
             FROM {{ ref(satellite) }}
         ) {{ satellite }}
         {% endif %}

--- a/macros/tables/trino/ref_sat_v1.sql
+++ b/macros/tables/trino/ref_sat_v1.sql
@@ -33,7 +33,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {%- for ref_key in ref_keys %} {{ref_key}} {%- if not loop.last %}, {% endif %}{% endfor %} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if source_columns_to_select -%},
         {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}

--- a/macros/tables/trino/sat_v1.sql
+++ b/macros/tables/trino/sat_v1.sql
@@ -29,7 +29,7 @@ end_dated_source AS (
         {%- endif %}
         {{ src_rsrc }},
         {{ src_ldts }},
-        COALESCE(LEAD({{ src_ldts }} - INTERVAL '0.001' SECOND) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
+        COALESCE(LEAD({{ datavault4dbt.subtract_clocktick(src_ldts) }}) OVER (PARTITION BY {{ hashkey }} ORDER BY {{ src_ldts }}),{{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}) as {{ ledts_alias }}
         {%- if include_payload -%},
             {{ datavault4dbt.print_list(source_columns_to_select) }}
         {%- endif %}


### PR DESCRIPTION
# Description

Two new global variables are included:

- datavault4dbt.clocktick_unit: dictionary of the unit for defining the clocktick in the data vault implementation per adapter (defaults to a unit corresponding to each adapter)
- datavault4dbt.step_size: the step_size for the clocktick in the unit as described above (defaults to 1)

A new supporting macro 'subtract_clocktick' was added and is now used in the sat_v1, ref_sat_v1, ma_sat_v1 and pit macro of every adapter. The supporting macro parses the correct subtraction string according to the used adapter. 
Theoretically, the implemented default values should deliver the same results as the hardcoded implementation at the moment, so the new feature should be completely backward compatible. 

Fixes #472 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (updated under docs\26_general-usage-notes\29_global-variables\29_global-variables.md)

# How Has This Been Tested?

I tested the functionality only for dbt-fabric! I used an examplary project, played around with the settings for fabric and it worked as expected. 
For the other adapters, I implemented similar functionality but was not able to test them in a real implementation! 

- [x] Tests you ran

**Test Configuration**:
* datavault4dbt-Version: fork from current main (last commit: bd87115)
* dbt-Version: dbt-core==1.11.12
* dbt-adapter-Version: dbt-fabric==1.10.0

# Checklist:

- [X] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
