### PR TITLE
fix: handling of `this`-object in unit tests of execution-aware runs

### DIFF
--- a/macros/supporting/source_models.sql
+++ b/macros/supporting/source_models.sql
@@ -54,7 +54,7 @@
             {% set ns_source_models.source_model_list = source_model_backup %}
         {% endif %}
 
-        {% if this is string or load_relation(this) is none or should_full_refresh() %}
+        {% if this is none or this is string or model.resource_type == 'unit_test' or load_relation(this) is none or should_full_refresh() %}
             {% if var('datavault4dbt.show_debug_logs', false) %}{{ log('Relation does not exist or should be full refreshed', false) }}{% endif %}
             {% set ns_source_models.source_model_list = source_model_backup %}
         {% endif %}

--- a/macros/supporting/source_models.sql
+++ b/macros/supporting/source_models.sql
@@ -54,7 +54,7 @@
             {% set ns_source_models.source_model_list = source_model_backup %}
         {% endif %}
 
-        {% if load_relation(this) is none or should_full_refresh() %}
+        {% if this is string or load_relation(this) is none or should_full_refresh() %}
             {% if var('datavault4dbt.show_debug_logs', false) %}{{ log('Relation does not exist or should be full refreshed', false) }}{% endif %}
             {% set ns_source_models.source_model_list = source_model_backup %}
         {% endif %}


### PR DESCRIPTION
  # Description

  In dbt unit tests, `this` is not a Relation object — depending on the dbt version it is a
  `str` or `None`. The execution-aware loading logic in `source_model_processing`
  (`macros/supporting/source_models.sql`) called `load_relation(this)` unguarded, which
  crashed at compile time when accessing `.database`:

  - `'str object' has no attribute 'database'` (as reported in the issue)
  - `'None' has no attribute 'database'` (observed during testing on a different dbt version)

  This broke unit tests for **all** entity macros using `source_model_processing`
  (hubs, links, nh_links, ref_hubs, rec_track_sats — all adapters).

  **The fix** adds short-circuiting guards *before* `load_relation(this)`:

  ```jinja
  {% if this is none or this is string or model.resource_type == 'unit_test' or load_relation(this) is none or should_full_refresh() %}
```
  - Jinja evaluates or chains left-to-right with short-circuiting, so load_relation is
  never called with a non-Relation value. (Note: appending a guard after
  load_relation(this) does not work — the crash happens before the guard is reached.)
  - this is none / this is string cover both observed unit-test representations;
  model.resource_type == 'unit_test' catches the unit test context semantically as a
  safety net for future dbt versions.
  - In unit test context the condition reverts to all source models — the same behavior
  as an initial load / --full-refresh, which is correct since unit tests mock their
  inputs and should compile against the full model logic rather than a runtime selection.
  - No behavior change for normal runs: there, this is always a Relation and
  model.resource_type == 'model', so evaluation falls through to the original
  load_relation(this) is none or should_full_refresh() logic unchanged.

  Single-line change; this is the only load_relation(this) call site in the package.

  Fixes #372 from the product development milestones:
  https://github.com/ScalefreeCOM/product_development_milestones/issues/372

  Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  How Has This Been Tested?

  - Tested end-to-end with the customer who reported the issue: unit tests on models using
  source_model_processing now compile and pass with
  multi_source_models__execution_aware_loading enabled. The temporary workaround
  (datavault4dbt.multi_source_models__execution_aware_loading: false) is no longer needed.
  - The intermediate state with only a this is string guard still failed on the customer's
  dbt version with 'None' has no attribute 'database' — confirming both guards are needed.
  - Verified the condition logic against all six states (this = None / str / Relation in
  unit test context; relation exists / missing / --full-refresh in normal runs): unit
  tests never invoke load_relation; normal runs behave exactly as before.

  Test Configuration:
  - datavault4dbt-Version: branch 372_this_unit_test_fix (based on main)
  - dbt-Version: cloud/core, version number
  - dbt-adapter-Version: dbt-snowflake, version number

  Checklist:

  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)