### PR TITLE
fix(docs): correct multi source execution aware loading global variable

### DIFF
--- a/docs/26_general-usage-notes/29_global-variables/29_global-variables.md
+++ b/docs/26_general-usage-notes/29_global-variables/29_global-variables.md
@@ -28,7 +28,7 @@ All the following variables are **prefixed with `datavault4dbt`**.
 |-------------------------------------------------|-----------------------|-------------|
 | include_business_objects_before_appearance      | Ref Table             | If a Ref_Hub entry should appear in the ref_table (snapshot based), even if the snapshot date is before the first appearance of that business object. |
 | enable_static_analysis_overwrite                | All macros            | Relevant for Fusion compatibility. For more info, see here. |
-| multi_source_models_execution_aware_loading     | Multi source entities | Whether multi source entities should respect the dbt command to reduce runtimes. |
+| multi_source_models__execution_aware_loading     | Multi source entities | Whether multi source entities should respect the dbt command to reduce runtimes. |
 | first_day_of_week                               | Snapshot Table        | A mapping dictionary that defines the integer representation of the first day of the week (Sunday vs. Monday) for each specific database adapter. For the full configuration matrix, see [Snapshot Control v0](../../01_macro-instructions/22_business-vault/24_snapshot-control/24_snapshot-control-v0.md). |
 | show_debug_logs                                 | All macros            | Whether verbose debug `log()` output should be written to the dbt `.log` file. Defaults to `false` to keep the log file clean. Set to `true` when troubleshooting macro behavior.  |
 ### COLUMN ALIASES


### PR DESCRIPTION
# Description

The variable to control the multi-source execution aware loading mechanism had a typo in the documentation