### PR TITLE
Fix rsrc_static LIKE mismatch in snowflake hub & link

### DIFF
--- a/macros/tables/snowflake/hub.sql
+++ b/macros/tables/snowflake/hub.sql
@@ -73,9 +73,9 @@ WITH
                 {%- endfor -%}
                 {%- set ns.last_cte = "rsrc_static_{}".format(source_number) -%}
             ),
-            
+
             {%- set source_in_target = true -%}
-            
+
             {%- if execute -%}
                 {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
@@ -157,9 +157,9 @@ WITH
         {% if var('datavault4dbt.show_debug_logs', false) %}{{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}{% endif %}
 
     {%- if is_incremental() and ns.has_rsrc_static_defined and ns.source_included_before[source_number|int] and not disable_hwm %}
-        WHERE 
+        WHERE
         {% for rsrc_static in rsrc_statics %}
-          (src.{{ src_rsrc }} = '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
+          (src.{{ src_rsrc }} LIKE '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
             SELECT MAX(max_ldts)
             FROM max_ldts_per_rsrc_static_in_target
             WHERE rsrc_static = '{{ rsrc_static }}' AND max_ldts != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
@@ -232,7 +232,7 @@ earliest_hk_over_all_sources AS (
 {%- if is_incremental() %}
 {# Get all link hashkeys out of the existing link for later incremental logic. #}
     distinct_target_hashkeys AS (
-        
+
         SELECT
         {{ hashkey }}
         FROM {{ this }}

--- a/macros/tables/snowflake/link.sql
+++ b/macros/tables/snowflake/link.sql
@@ -75,7 +75,7 @@ WITH
             ),
 
             {%- set source_in_target = true -%}
-            
+
             {%- if execute -%}
                 {%- set rsrc_static_result = run_query(rsrc_static_query_source) -%}
 
@@ -162,9 +162,9 @@ WITH
         {% if var('datavault4dbt.show_debug_logs', false) %}{{ log('rsrc_statics defined?: ' ~ ns.source_models_rsrc_dict[source_number|string], false) }}{% endif %}
 
     {%- if is_incremental() and ns.has_rsrc_static_defined and ns.source_included_before[source_number|int] and not disable_hwm %}
-        WHERE 
+        WHERE
         {% for rsrc_static in rsrc_statics %}
-          (src.{{ src_rsrc }} = '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
+          (src.{{ src_rsrc }} LIKE '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
             SELECT MAX(max_ldts)
             FROM max_ldts_per_rsrc_static_in_target
             WHERE rsrc_static = '{{ rsrc_static }}' AND max_ldts != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
@@ -237,7 +237,7 @@ earliest_hk_over_all_sources AS (
 {%- if is_incremental() %}
 {# Get all link hashkeys out of the existing link for later incremental logic. #}
     distinct_target_hashkeys AS (
-        
+
         SELECT
         {{ link_hashkey }}
         FROM {{ this }}


### PR DESCRIPTION
> EDIT: All of this also applies to links.

# Description

**Background: what is `rsrc_static`?**
When declaring a hub's source models, datavault4dbt lets you optionally set an `rsrc_static` parameter per source — a literal value that identifies where records from that source came from, used purely to speed up the incremental (High-Water-Mark) lookup instead of scanning the full hub for `MAX(ldts)`. The docs and most examples use a plain literal (e.g. a source system name), but the macro also accepts SQL `LIKE` patterns (e.g. `%some/file/path/%`) for cases where the actual `rsrc` column contains variable values that only share a common substring/pattern — e.g. when `rsrc` is populated with a file path, URL, or other per-batch identifier rather than a fixed constant.

**What is the bug?**
In the incremental HWM path of the macro, the CTEs that look up the existing max load-timestamp per source (`rsrc_static_<n>`, `max_ldts_per_rsrc_static_in_target`) correctly compare `rsrc` against `rsrc_static` using `LIKE`:
```sql
src.<rsrc> LIKE '<rsrc_static>'
```
But the `src_new` CTE, which selects the actual new rows to load, filters with equality instead:
```sql
src.<rsrc> = '<rsrc_static>'
```
This inconsistency only matters when `rsrc_static` is defined as a wildcard pattern rather than a literal value. In that case, a real `rsrc` value is never `=` equal to a `%...%` pattern — the comparison is always `false`. So on any incremental run after a source has been loaded at least once (`source_included_before = true`), `src_new` selects **zero rows** for that source, and new business keys silently stop reaching the hub. Full/initial loads are unaffected, since this code path only runs `is_incremental()`.

**When does this occur, and why does it matter?**
- Applies only to hubs where `rsrc_static` is configured as a `LIKE`-style pattern rather than an exact literal — this is a supported, documented use case of the macro, not a misconfiguration.
- Because the bug only manifests on the *second and later* incremental runs per source (the first run still has `source_included_before = false`), it is easy to miss in initial testing or a quick CI check that only exercises a fresh/first load.
- Confirmed present in datavault4dbt 1.17.0, v1.18.x, v2.0.1, and `main` — anyone relying on wildcard `rsrc_static` values is affected regardless of package version, and simply upgrading the package does not resolve it.

**Fix:**
Changed the `src_new` filter from `=` to `LIKE`, making it consistent with the HWM lookup CTEs above it. The unrelated `WHERE rsrc_static = '...'` comparison in the lookup subqueries was intentionally left as `=`, since there it compares a pattern literal against itself, not against an `rsrc` value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Tests you ran:

Did test this in our data platform project where the incremental run had the issues described above. Now it works correctly.


# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas **(not neccessary from my pov)**
- [X] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki) **(not neccessary from my pov)**
