### PR TITLE
added subquery logic for unit tests

### DIFF
--- a/macros/tables/snowflake/eff_sat_v0.sql
+++ b/macros/tables/snowflake/eff_sat_v0.sql
@@ -4,7 +4,7 @@
 {%- set timestamp_format = datavault4dbt.timestamp_format() -%}
 {%- set beginning_of_all_times = datavault4dbt.beginning_of_all_times() -%}
 
-{%- set ns = namespace(last_cte= "") -%}
+{%- set ns = namespace(last_cte="", use_subquery_hwm=false) -%}
 
 {%- set source_relation = ref(source_model) -%}
 
@@ -26,9 +26,13 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~ src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
-        {% set max_ldts_results = run_query(max_ldts_query) %}
-        {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- if '__dbt__cte__' in (this | string | lower) -%}
+            {%- set ns.use_subquery_hwm = true -%}
+        {%- else -%}
+            {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~ src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
+            {% set max_ldts_results = run_query(max_ldts_query) %}
+            {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- endif %}
     {%- endif %}
 {% endif %}
 
@@ -52,7 +56,15 @@ source_data AS (
     FROM {{ source_relation }} src
     WHERE {{ src_ldts }} NOT IN ('{{ datavault4dbt.beginning_of_all_times() }}', '{{ datavault4dbt.end_of_all_times() }}')
     {%- if is_incremental() and not disable_hwm %}
+    {%- if ns.use_subquery_hwm %}
+    AND src.{{ src_ldts }} > (
+        SELECT COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }})
+        FROM {{ this }}
+        WHERE {{ src_ldts }} < {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
+    {%- else %}
     AND src.{{ src_ldts }} > '{{ max_ldts }}'
+    {%- endif %}
     {%- endif %}
 ),
 

--- a/macros/tables/snowflake/eff_sat_v0.sql
+++ b/macros/tables/snowflake/eff_sat_v0.sql
@@ -26,7 +26,9 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {%- if '__dbt__cte__' in (this | string | lower) -%}
+        {%- if this is none -%}
+            {{ exceptions.raise_compiler_error("datavault4dbt: `this` is not available. If this is a unit test on an incremental model, add the model itself as a `given` input so dbt can populate `this`.") }}
+        {%- elif this is string -%}
             {%- set ns.use_subquery_hwm = true -%}
         {%- else -%}
             {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~ src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}

--- a/macros/tables/snowflake/ma_sat_v0.sql
+++ b/macros/tables/snowflake/ma_sat_v0.sql
@@ -8,7 +8,7 @@
 {%- set additional_columns = additional_columns | default([],true) -%}
 {%- set additional_columns = [additional_columns] if additional_columns is string else additional_columns -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="", use_subquery_hwm=false) %}
 {%- if  src_hashdiff is mapping and src_hashdiff is not none -%}
     {% set ns.src_hashdiff = src_hashdiff["source_column"] %}
     {% set ns.hdiff_alias = src_hashdiff["alias"] %}
@@ -22,9 +22,13 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
-        {% set max_ldts_results = run_query(max_ldts_query) %}
-        {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- if '__dbt__cte__' in (this | string | lower) -%}
+            {%- set ns.use_subquery_hwm = true -%}
+        {%- else -%}
+            {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
+            {% set max_ldts_results = run_query(max_ldts_query) %}
+            {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- endif %}
     {%- endif %}
 {% endif %}
 
@@ -44,7 +48,15 @@ source_data AS (
     FROM {{ source_relation }}
 
     {%- if is_incremental() and not disable_hwm %}
+    {%- if ns.use_subquery_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }})
+        FROM {{ this }}
+        WHERE {{ src_ldts }} < {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
+    {%- else %}
     WHERE {{ src_ldts }} > '{{ max_ldts }}'
+    {%- endif %}
     {%- endif %}
     
     {% set source_cte = 'source_data' %}

--- a/macros/tables/snowflake/ma_sat_v0.sql
+++ b/macros/tables/snowflake/ma_sat_v0.sql
@@ -22,7 +22,9 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {%- if '__dbt__cte__' in (this | string | lower) -%}
+        {%- if this is none -%}
+            {{ exceptions.raise_compiler_error("datavault4dbt: `this` is not available. If this is a unit test on an incremental model, add the model itself as a `given` input so dbt can populate `this`.") }}
+        {%- elif this is string -%}
             {%- set ns.use_subquery_hwm = true -%}
         {%- else -%}
             {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}

--- a/macros/tables/snowflake/ref_sat_v0.sql
+++ b/macros/tables/snowflake/ref_sat_v0.sql
@@ -34,7 +34,9 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {%- if '__dbt__cte__' in (this | string | lower) -%}
+        {%- if this is none -%}
+            {{ exceptions.raise_compiler_error("datavault4dbt: `this` is not available. If this is a unit test on an incremental model, add the model itself as a `given` input so dbt can populate `this`.") }}
+        {%- elif this is string -%}
             {%- set ns.use_subquery_hwm = true -%}
         {%- else -%}
             {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~ src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}

--- a/macros/tables/snowflake/ref_sat_v0.sql
+++ b/macros/tables/snowflake/ref_sat_v0.sql
@@ -11,7 +11,7 @@
 {%- set payload_count = src_payload | length -%}
 {%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="", use_subquery_hwm=false) %}
 {%- if has_hashdiff -%}
     {%- if src_hashdiff is mapping -%}
         {%- set ns.src_hashdiff = src_hashdiff["source_column"] -%}
@@ -34,9 +34,13 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~ src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
-        {% set max_ldts_results = run_query(max_ldts_query) %}
-        {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- if '__dbt__cte__' in (this | string | lower) -%}
+            {%- set ns.use_subquery_hwm = true -%}
+        {%- else -%}
+            {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~ src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
+            {% set max_ldts_results = run_query(max_ldts_query) %}
+            {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- endif %}
     {%- endif %}
 {% endif %}
 
@@ -56,7 +60,15 @@ source_data AS (
     FROM {{ source_relation }}
 
     {%- if is_incremental() and not disable_hwm %}
+    {%- if ns.use_subquery_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }})
+        FROM {{ this }}
+        WHERE {{ src_ldts }} < {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
+    {%- else %}
     WHERE {{ src_ldts }} > '{{ max_ldts }}'
+    {%- endif %}
     {%- endif %}
     {%- set last_cte = 'source_data' -%}
 ),

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -9,7 +9,7 @@
 {%- set payload_count = src_payload | length -%}
 {%- set has_hashdiff = src_hashdiff is not none and src_hashdiff != '' -%}
 
-{%- set ns=namespace(src_hashdiff="", hdiff_alias="") %}
+{%- set ns=namespace(src_hashdiff="", hdiff_alias="", use_subquery_hwm=false) %}
 
 {%- if has_hashdiff -%}
     {%- if src_hashdiff is mapping -%}
@@ -34,9 +34,13 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
-        {% set max_ldts_results = run_query(max_ldts_query) %}
-        {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- if '__dbt__cte__' in (this | string | lower) -%}
+            {%- set ns.use_subquery_hwm = true -%}
+        {%- else -%}
+            {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}
+            {% set max_ldts_results = run_query(max_ldts_query) %}
+            {% set max_ldts = max_ldts_results.columns[0].values()[0] %}
+        {%- endif %}
     {%- endif %}
 {% endif %}
 
@@ -56,7 +60,15 @@ source_data AS (
     FROM {{ source_relation }}
 
     {%- if is_incremental() and not disable_hwm %}
+    {%- if ns.use_subquery_hwm %}
+    WHERE {{ src_ldts }} > (
+        SELECT COALESCE(MAX({{ src_ldts }}), {{ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) }})
+        FROM {{ this }}
+        WHERE {{ src_ldts }} < {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}
+    )
+    {%- else %}
     WHERE {{ src_ldts }} > '{{ max_ldts }}'
+    {%- endif %}
     {%- endif %}
 
     {%- set last_cte = 'source_data' -%}

--- a/macros/tables/snowflake/sat_v0.sql
+++ b/macros/tables/snowflake/sat_v0.sql
@@ -34,7 +34,9 @@
 {# Get max(ldts) #}
 {% if execute %}
     {%- if is_incremental() and not disable_hwm %}
-        {%- if '__dbt__cte__' in (this | string | lower) -%}
+        {%- if this is none -%}
+            {{ exceptions.raise_compiler_error("datavault4dbt: `this` is not available. If this is a unit test on an incremental model, add the model itself as a `given` input so dbt can populate `this`.") }}
+        {%- elif this is string -%}
             {%- set ns.use_subquery_hwm = true -%}
         {%- else -%}
             {% set max_ldts_query = 'SELECT COALESCE(MAX(' ~src_ldts ~ '), ' ~ datavault4dbt.string_to_timestamp(timestamp_format, beginning_of_all_times) ~ ')  FROM ' ~ this ~' WHERE '~ src_ldts ~' < '~datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times)  %}


### PR DESCRIPTION
# Description

The Snowflake satellite macros (sat_v0, ref_sat_v0, eff_sat_v0, ma_sat_v0) pre-calculate the HWM via a separate run_query() call. During dbt unit tests, this resolves to a __dbt__cte__… that doesn't exist yet when run_query() fires, causing:

  ▎ Object 'DBT__CTE__…' does not exist or not authorized

Fix: When this resolves to a CTE (unit test context), skip run_query() and inline the HWM as a subquery instead. The same pattern used by all other adapters. Production runs are unchanged.

Fixes #(373)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- local unit tests

**Test Configuration**:
* datavault4dbt-Version:
* dbt-Version: _cloud/core, version number_
* dbt-adapter-Version:

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or included information that needs updates (e.g. in the Wiki)
