### PR TITLE
Fix rsrc static missmatch in snowflake

### DIFF
--- a/macros/tables/snowflake/hub.sql
+++ b/macros/tables/snowflake/hub.sql
@@ -159,7 +159,7 @@ WITH
     {%- if is_incremental() and ns.has_rsrc_static_defined and ns.source_included_before[source_number|int] and not disable_hwm %}
         WHERE 
         {% for rsrc_static in rsrc_statics %}
-          (src.{{ src_rsrc }} = '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
+          (src.{{ src_rsrc }} like '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
             SELECT MAX(max_ldts)
             FROM max_ldts_per_rsrc_static_in_target
             WHERE rsrc_static = '{{ rsrc_static }}' AND max_ldts != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}

--- a/macros/tables/snowflake/link.sql
+++ b/macros/tables/snowflake/link.sql
@@ -164,7 +164,7 @@ WITH
     {%- if is_incremental() and ns.has_rsrc_static_defined and ns.source_included_before[source_number|int] and not disable_hwm %}
         WHERE 
         {% for rsrc_static in rsrc_statics %}
-          (src.{{ src_rsrc }} = '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
+          (src.{{ src_rsrc }} like '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
             SELECT MAX(max_ldts)
             FROM max_ldts_per_rsrc_static_in_target
             WHERE rsrc_static = '{{ rsrc_static }}' AND max_ldts != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}

--- a/macros/tables/snowflake/nh_link.sql
+++ b/macros/tables/snowflake/nh_link.sql
@@ -182,7 +182,7 @@ src_new_{{ source_number }} AS (
     {%- if is_incremental() and ns.has_rsrc_static_defined and ns.source_included_before[source_number|int] and not disable_hwm %}
         WHERE 
         {% for rsrc_static in rsrc_statics %}
-          (src.{{ src_rsrc }} = '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
+          (src.{{ src_rsrc }} like '{{ rsrc_static }}' AND src.{{ src_ldts }} > (
             SELECT MAX(max_ldts)
             FROM max_ldts_per_rsrc_static_in_target
             WHERE rsrc_static = '{{ rsrc_static }}' AND max_ldts != {{ datavault4dbt.string_to_timestamp(timestamp_format, end_of_all_times) }}


### PR DESCRIPTION
# Description

Fixed RSRC static missmatch as snowflake does not support wildcard operators in = instead it has to use the keyword like
When the rsrc_static is defined as rsrc_static = '%Test123%' snowflake trests it as string literal in the where clause of src_new_x
`    src_new_1 AS (

        SELECT
            hk_1,
            hk_2_hub,
            hk_3_hub,
            ldts,
            rsrc
        FROM stage src
        
        WHERE 
        
          (src.rsrc= '%Test123%' AND src.ldts> (
            SELECT MAX(max_ldts)
            FROM max_ldts_per_rsrc_static_in_target
            WHERE rsrc_static = '%Test123%' AND max_ldts != TO_TIMESTAMP('8888-12-31T23:59:59', 'YYYY-MM-DDTHH24:MI:SS')
            ))

    )`
Therefore not resolving the right entries in a delta load this is fixed by replacing the src.rsrc = with an src.rsrc like
Which I've done in the Hub, Link and nh_link the rec_track_satellite does not need this yet as it's still in the old format like hubs, links and nh_links used to be in 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

I've testes the entities cause after a full DV refresh the next daily load produced relationship errors between sat's and links/hubs. I've implemented the changes locally and ran the entities again and the newest delta was successfully loaded

- [x] Tests you ran

**Test Configuration**:
* datavault4dbt-Version: 2.1.0
* dbt-Version: _cloud, version number newest

# Checklist:

- [x] I have performed a self-review of my code
